### PR TITLE
feat: support gradient in stroke

### DIFF
--- a/tester/harmony/svg/src/main/cpp/SvgGraphic.cpp
+++ b/tester/harmony/svg/src/main/cpp/SvgGraphic.cpp
@@ -39,28 +39,26 @@ void SvgGraphic::OnDraw(OH_Drawing_Canvas *canvas) {
     //     OH_Drawing_PenReset(strokePen_.get());
     // 获取子类的绘制路径。
     path_ = AsPath();
-    UpdateGradient();
+    UpdateGradient(attributes_.fillState.GetGradient());
+    UpdateGradient(attributes_.strokeState.GetGradient());
     if (UpdateFillStyle()) {
         OnGraphicFill(canvas);
     }
-    //     OnGraphicFill(canvas);
-    UpdateStrokeStyle();
-    OnGraphicStroke(canvas);
+    if (UpdateStrokeStyle()) {
+        OnGraphicStroke(canvas);
+    }
     if (!attributes_.markerStart.empty() || !attributes_.markerMid.empty() || !attributes_.markerEnd.empty()) {
-        LOG(INFO) << "DRaw marker";
         DrawMarker(canvas);
     }
 }
 void SvgGraphic::OnGraphicFill(OH_Drawing_Canvas *canvas) {
     auto smoothEdge = GetSmoothEdge();
     if (GreatNotEqual(smoothEdge, 0.0f)) {
-        LOG(INFO) << "[svg] OnGraphicFill1";
         auto *filter = OH_Drawing_FilterCreate();
         auto *maskFilter =
             OH_Drawing_MaskFilterCreateBlur(OH_Drawing_BlurType::NORMAL, static_cast<double>(smoothEdge), false);
         OH_Drawing_FilterSetMaskFilter(filter, maskFilter);
 
-        /* copy constructor missing */
         auto tmpFillBrush = fillBrush_;
         OH_Drawing_BrushSetFilter(tmpFillBrush.get(), filter);
         OH_Drawing_CanvasAttachBrush(canvas, tmpFillBrush.get());
@@ -70,7 +68,6 @@ void SvgGraphic::OnGraphicFill(OH_Drawing_Canvas *canvas) {
         OH_Drawing_FilterDestroy(filter);
         OH_Drawing_MaskFilterDestroy(maskFilter);
     } else {
-        LOG(INFO) << "[svg] OnGraphicFill2";
         OH_Drawing_CanvasAttachBrush(canvas, fillBrush_.get());
         OH_Drawing_CanvasDrawPath(canvas, path_.get());
         OH_Drawing_CanvasDetachBrush(canvas);
@@ -81,13 +78,11 @@ void SvgGraphic::OnGraphicFill(OH_Drawing_Canvas *canvas) {
 void SvgGraphic::OnGraphicStroke(OH_Drawing_Canvas *canvas) {
     auto smoothEdge = GetSmoothEdge();
     if (GreatNotEqual(smoothEdge, 0.0f)) {
-        LOG(INFO) << "[svg] OnGraphicStroke1";
         auto *filter = OH_Drawing_FilterCreate();
         auto *maskFilter =
             OH_Drawing_MaskFilterCreateBlur(OH_Drawing_BlurType::NORMAL, static_cast<double>(smoothEdge), false);
         OH_Drawing_FilterSetMaskFilter(filter, maskFilter);
 
-        /* copy constructor missing */
         auto tmpStrokePen = strokePen_;
         OH_Drawing_PenSetFilter(tmpStrokePen.get(), filter);
         OH_Drawing_CanvasAttachPen(canvas, tmpStrokePen.get());
@@ -97,7 +92,6 @@ void SvgGraphic::OnGraphicStroke(OH_Drawing_Canvas *canvas) {
         OH_Drawing_FilterDestroy(filter);
         OH_Drawing_MaskFilterDestroy(maskFilter);
     } else {
-        LOG(INFO) << "[svg] OnGraphicStroke2";
         const auto &transform = attributes_.transform;
         if (attributes_.strokeState.GetVectorEffect() && transform.size() > 5) {
             auto matrix = drawing::Matrix();
@@ -113,9 +107,7 @@ void SvgGraphic::OnGraphicStroke(OH_Drawing_Canvas *canvas) {
 }
 
 // todo implement bounds
-void SvgGraphic::UpdateGradient() {
-    auto &fillState_ = attributes_.fillState;
-    auto &gradient = fillState_.GetGradient();
+void SvgGraphic::UpdateGradient(std::optional<Gradient> &gradient) {
     CHECK_NULL_VOID(gradient);
     // objectBoundingBox - 0(DEFAULT), userSpaceOnUse - 1
     auto nodeBounds = (gradient->GetGradientUnits() == Unit::objectBoundingBox)
@@ -174,6 +166,7 @@ void SvgGraphic::UpdateGradient() {
         gradient->SetRadialGradientInfo(gradientInfo);
     }
 }
+
 bool SvgGraphic::UpdateFillStyle(bool antiAlias) {
     const auto &fillState_ = attributes_.fillState;
     if (fillState_.GetColor() == Color::TRANSPARENT && !fillState_.GetGradient() && !fillState_.GetPatternAttr()) {
@@ -182,10 +175,8 @@ bool SvgGraphic::UpdateFillStyle(bool antiAlias) {
     double curOpacity = fillState_.GetOpacity() * attributes_.opacity;
     fillBrush_.SetAntiAlias(antiAlias);
     if (fillState_.GetGradient()) {
-        LOG(INFO) << "[SVGGraphic] SetGradientStyle";
-        SetGradientStyle(curOpacity);
+        SetFillGradientStyle(curOpacity);
     } else if (fillState_.GetPatternAttr()) {
-        LOG(INFO) << "[SVGGraphic] SetPatternStyle";
         return SetPatternStyle();
     } else {
         fillBrush_.SetColor(fillState_.GetColor().BlendOpacity(curOpacity).GetValue());
@@ -193,7 +184,7 @@ bool SvgGraphic::UpdateFillStyle(bool antiAlias) {
     }
     return true;
 }
-void SvgGraphic::SetGradientStyle(double opacity) {
+void SvgGraphic::SetFillGradientStyle(double opacity) {
     const auto &fillState_ = attributes_.fillState;
     auto gradient = fillState_.GetGradient();
     CHECK_NULL_VOID(gradient);
@@ -239,6 +230,57 @@ void SvgGraphic::SetGradientStyle(double opacity) {
         concatMatrix = scaleMatrix.Concat(transMatrix);
         fillBrush_.SetRadialShaderEffect(&focal, 0, &center, info.rx > info.ry ? info.rx : info.ry, colors.data(),
             pos.data(), colors.size(), static_cast<OH_Drawing_TileMode>(gradient->GetSpreadMethod()), concatMatrix.get());
+    }
+}
+
+void SvgGraphic::SetStrokeGradientStyle(double opacity) {
+    const auto &strokeState_ = attributes_.strokeState;
+    auto gradient = strokeState_.GetGradient();
+    CHECK_NULL_VOID(gradient);
+    auto gradientColors = gradient->GetColors();
+    if (gradientColors.empty()) {
+        return;
+    }
+    std::vector<float> pos;
+    std::vector<uint32_t> colors;
+    for (const auto &gradientColor : gradientColors) {
+        pos.push_back(static_cast<float>(gradientColor.GetDimension().Value()));
+        colors.push_back(
+            gradientColor.GetColor().BlendOpacity(gradientColor.GetOpacity()).BlendOpacity(opacity).GetValue());
+    }
+    drawing::Matrix transMatrix;
+    if (gradient->GetGradientTransform().size() == 9) {
+        transMatrix.SetMatrix(gradient->GetGradientTransform()[0], gradient->GetGradientTransform()[1],
+                              gradient->GetGradientTransform()[2], gradient->GetGradientTransform()[3],
+                              gradient->GetGradientTransform()[4], gradient->GetGradientTransform()[5],
+                              gradient->GetGradientTransform()[6], gradient->GetGradientTransform()[7],
+                              gradient->GetGradientTransform()[8]);
+    }
+    if (gradient->GetType() == GradientType::LINEAR && gradient->IsValid()) {
+        auto info = gradient->GetLinearGradientInfo();
+        OH_Drawing_Point2D ptsPoint2D[2] = {
+            {static_cast<float>(info.x1), static_cast<float>(info.y1)},
+            {static_cast<float>(info.x2), static_cast<float>(info.y2)},
+        };
+        strokePen_.SetLinearShaderEffect(&ptsPoint2D[0], &ptsPoint2D[1], colors.data(), pos.data(), colors.size(),
+                                         static_cast<OH_Drawing_TileMode>(gradient->GetSpreadMethod()),
+                                         transMatrix.get());
+    }
+    if (gradient->GetType() == GradientType::RADIAL && gradient->IsValid()) {
+        auto info = gradient->GetRadialGradientInfo();
+        drawing::Matrix scaleMatrix;
+        if (info.ry < info.rx) {
+            scaleMatrix = drawing::Matrix::CreateScale(1, info.ry / info.rx, info.cx, info.cy);
+        } else {
+            scaleMatrix = drawing::Matrix::CreateScale(info.rx / info.ry, 1, info.cx, info.cy);
+        }
+        OH_Drawing_Point2D focal = {static_cast<float>(info.fx), static_cast<float>(info.fy)};
+        OH_Drawing_Point2D center = {static_cast<float>(info.cx), static_cast<float>(info.cy)};
+        drawing::Matrix concatMatrix;
+        concatMatrix = scaleMatrix.Concat(transMatrix);
+        strokePen_.SetRadialShaderEffect(
+            &focal, 0, &center, info.rx > info.ry ? info.rx : info.ry, colors.data(), pos.data(), colors.size(),
+            static_cast<OH_Drawing_TileMode>(gradient->GetSpreadMethod()), concatMatrix.get());
     }
 }
 
@@ -372,7 +414,11 @@ bool SvgGraphic::UpdateStrokeStyle(bool antiAlias) {
     }
 
     double curOpacity = strokeState.GetOpacity() * attributes_.opacity;
-    strokePen_.SetColor(strokeState.GetColor().BlendOpacity(curOpacity).GetValue());
+    if (strokeState.GetGradient()) {
+        SetStrokeGradientStyle(curOpacity);
+    } else {
+        strokePen_.SetColor(strokeState.GetColor().BlendOpacity(curOpacity).GetValue());
+    }
     LOG(INFO) << "[svg] strokeState.GetLineCap(): " << static_cast<int>(strokeState.GetLineCap());
     if (strokeState.GetLineCap() == LineCapStyle::ROUND) {
         strokePen_.SetLineCap(LINE_ROUND_CAP);

--- a/tester/harmony/svg/src/main/cpp/SvgGraphic.h
+++ b/tester/harmony/svg/src/main/cpp/SvgGraphic.h
@@ -34,8 +34,9 @@ protected:
 
     bool UpdateFillStyle(bool antiAlias = true);
     bool UpdateStrokeStyle(bool antiAlias = true);
-    void UpdateGradient();
-    void SetGradientStyle(double opacity);
+    void UpdateGradient(std::optional<Gradient> &gradient);
+    void SetFillGradientStyle(double opacity);
+    void SetStrokeGradientStyle(double opacity);
     bool SetPatternStyle();
     void UpdateLineDash();
 

--- a/tester/harmony/svg/src/main/cpp/drawing/Pen.cpp
+++ b/tester/harmony/svg/src/main/cpp/drawing/Pen.cpp
@@ -25,6 +25,27 @@ void Pen::SetLineCap(LineCapStyle lineCap) { OH_Drawing_PenSetCap(pen_.get(), li
 
 void Pen::SetLineJoin(LineJoinStyle lineJoin) { OH_Drawing_PenSetJoin(pen_.get(), lineJoin); }
 
+void Pen::SetLinearShaderEffect(const OH_Drawing_Point2D *startPt, const OH_Drawing_Point2D *endPt,
+                                  const uint32_t *colors, const float *pos, uint32_t size, OH_Drawing_TileMode mode,
+                                  const OH_Drawing_Matrix *mat) {
+    penShaderEffect_.ShaderEffectCreateLinearGradient(startPt, endPt, colors, pos, size, mode, mat);
+    OH_Drawing_PenSetShaderEffect(pen_.get(), penShaderEffect_.get());
+}
+
+void Pen::SetRadialShaderEffect(const OH_Drawing_Point2D *startPt, float startRadius, const OH_Drawing_Point2D *endPt,
+                                  float endRadius, const uint32_t *colors, const float *pos, uint32_t size,
+                                  OH_Drawing_TileMode mode, const OH_Drawing_Matrix *mat) {
+    penShaderEffect_.ShaderEffectCreateRadialGradient(startPt, startRadius, endPt, endRadius, colors, pos, size, mode,
+                                                        mat);
+    OH_Drawing_PenSetShaderEffect(pen_.get(), penShaderEffect_.get());
+}
+
+void Pen::SetImageShaderEffect(OH_Drawing_Image *image, OH_Drawing_TileMode tileX, OH_Drawing_TileMode tileY,
+                                 const OH_Drawing_SamplingOptions *opt, const OH_Drawing_Matrix *mat) {
+    penShaderEffect_.ShaderEffectCreateImageShader(image, tileX, tileY, opt, mat);
+    OH_Drawing_PenSetShaderEffect(pen_.get(), penShaderEffect_.get());
+}
+
 void Pen::Reset() {}
 
 } // namespace rnoh::drawing

--- a/tester/harmony/svg/src/main/cpp/drawing/Pen.h
+++ b/tester/harmony/svg/src/main/cpp/drawing/Pen.h
@@ -1,7 +1,9 @@
 #pragma once
 
+#include "ShaderEffect.h"
 #include <memory>
 #include <native_drawing/drawing_pen.h>
+#include <native_drawing/drawing_shader_effect.h>
 
 namespace rnoh::drawing {
 
@@ -30,6 +32,14 @@ public:
     void SetMiterLimit(float miterLimit);
     void SetLineCap(LineCapStyle lineCap);
     void SetLineJoin(LineJoinStyle lineJoin);
+    void SetLinearShaderEffect(const OH_Drawing_Point2D *startPt, const OH_Drawing_Point2D *endPt,
+                               const uint32_t *colors, const float *pos, uint32_t size, OH_Drawing_TileMode mode,
+                               const OH_Drawing_Matrix *mat);
+    void SetRadialShaderEffect(const OH_Drawing_Point2D *startPt, float startRadius, const OH_Drawing_Point2D *endPt,
+                               float endRadius, const uint32_t *colors, const float *pos, uint32_t size,
+                               OH_Drawing_TileMode mode, const OH_Drawing_Matrix *mat);
+    void SetImageShaderEffect(OH_Drawing_Image *image, OH_Drawing_TileMode tileX, OH_Drawing_TileMode tileY,
+                              const OH_Drawing_SamplingOptions *opt, const OH_Drawing_Matrix *mat);
 
     void Reset();
 
@@ -37,6 +47,7 @@ public:
 
 private:
     UniqueNativePen pen_;
+    ShaderEffect penShaderEffect_;
 };
 
 } // namespace rnoh::drawing

--- a/tester/harmony/svg/src/main/cpp/properties/SvgPaintState.h
+++ b/tester/harmony/svg/src/main/cpp/properties/SvgPaintState.h
@@ -1,12 +1,6 @@
 // from ArkUI "frameworks/core/components/common/properties/svg_paint_state.h"
 #pragma once
 
-// #include "base/memory/ace_type.h"
-// #include "core/components/common/properties/animatable_double.h"
-// #include "frameworks/core/components/common/layout/constants.h"
-// #include "frameworks/core/components/common/properties/decoration.h"
-// #include "frameworks/core/components/common/properties/paint_state.h"
-// #include "frameworks/core/components/common/properties/text_style.h"
 #include "Decoration.h"
 #include "properties/Color.h"
 #include "properties/PaintState.h"
@@ -55,16 +49,16 @@ public:
 
     std::optional<Gradient> &GetGradient() { return gradient_; }
 
-    std::shared_ptr<PatternAttr> &GetPatternAttr() { return patternAttr_; }
-
     const std::optional<Gradient> &GetGradient() const { return gradient_; }
-
-    const std::shared_ptr<PatternAttr> &GetPatternAttr() const { return patternAttr_; }
 
     void SetGradient(const Gradient &gradient, bool isSelf) {
         gradient_ = std::make_optional(gradient);
         hasGradient_ = isSelf;
     }
+
+    std::shared_ptr<PatternAttr> &GetPatternAttr() { return patternAttr_; }
+    
+    const std::shared_ptr<PatternAttr> &GetPatternAttr() const { return patternAttr_; }
 
     void SetPattern(std::shared_ptr<PatternAttr> patternAttr) {
         patternAttr_ = patternAttr;
@@ -149,6 +143,15 @@ public:
     {
         color_ = color;
         hasColor_ = isSelf;
+    }
+
+    std::optional<Gradient> &GetGradient() { return gradient_; }
+
+    const std::optional<Gradient> &GetGradient() const { return gradient_; }
+
+    void SetGradient(const Gradient &gradient, bool isSelf) {
+        gradient_ = std::make_optional(gradient);
+        hasGradient_ = isSelf;
     }
 
     void SetOpacity(double opacity, bool isSelf)
@@ -300,6 +303,9 @@ public:
         if (!hasStrokeDashOffset_) {
             strokeDashOffset_ = strokeState.GetStrokeDashOffset();
         }
+        if (!hasGradient_) {
+            gradient_ = strokeState.GetGradient();
+        }
     }
 
     bool HasColor() const
@@ -349,6 +355,8 @@ private:
     double strokeDashOffset_;
     std::string href_;
     int vectorEffect_ = 0;
+    std::optional<Gradient> gradient_;
+
     bool hasColor_ = false;
     bool hasOpacity_ = false;
     bool hasLineCap_ = false;
@@ -359,6 +367,7 @@ private:
     bool hasDashOffset_ = false;
     bool hasStrokeDashArray_ = false;
     bool hasStrokeDashOffset_ = false;
+    bool hasGradient_ = false;
 };
 
 class ClipState {

--- a/tester/svgDemoCases/components/IssueFix.tsx
+++ b/tester/svgDemoCases/components/IssueFix.tsx
@@ -58,7 +58,30 @@ class SvgLayoutExample extends Component {
   }
 }
 
-const samples = [SvgLayoutExample];
+class Issue178 extends Component {
+  static title = 'Stroke LinearGradient';
+  render() {
+    return (
+      <Svg style={{height: 200, width: 374.1538391113281}}>
+        <Defs key={'gradient'}>
+          <LinearGradient id={'gradient'} x1="0%" y1="0%" x2="100%" y2="0%">
+            <Stop offset={'0%'} stopColor={'rgb(134, 65, 244)'} />
+            <Stop offset={'100%'} stopColor={'rgb(66, 194, 244)'} />
+          </LinearGradient>
+        </Defs>
+        <Path
+          d="M0,61.14285714285714L26.725274222237722,97.71428571428572L53.450548444475444,70.28571428571428L80.17582266671316,20L106.90109688895089,110.51428571428572L133.62637111118863,128.79999999999998L160.35164533342632,29.142857142857146L187.07691955566406,23.657142857142865L213.80219377790178,74.85714285714286L240.52746800013952,58.39999999999999L267.25274222237726,155.31428571428572L293.9780164446149,84.91428571428571L320.70329066685264,61.14285714285714L347.4285648890904,125.14285714285715L374.1538391113281,180"
+          fillOpacity={0}
+          stroke="url(#gradient)"
+          strokeWidth="4"
+          >
+          </Path>
+      </Svg>
+    );
+  }
+}
+
+const samples = [SvgLayoutExample, Issue178];
 
 const styles = StyleSheet.create({
   container: {
@@ -81,6 +104,9 @@ export default function () {
       <ScrollView>
         <TestCase itShould="SVG with flex layout">
           <SvgLayoutExample />
+        </TestCase>
+        <TestCase itShould="Issue#178: Stroke color should have linear gradient">
+          <Issue178 />
         </TestCase>
       </ScrollView>
     </Tester>


### PR DESCRIPTION
# Summary
Support setting gradient in stroke.

# Test Plan
Test is available in svgDemoCases IssueFix section as Issue#178

Resolve [#178](https://github.com/react-native-oh-library/react-native-harmony-svg/issues/178).