### PR TITLE
fix: Path fails to display correctly

### DIFF
--- a/tester/harmony/svg/src/main/cpp/SvgPath.cpp
+++ b/tester/harmony/svg/src/main/cpp/SvgPath.cpp
@@ -22,8 +22,9 @@
 namespace rnoh {
 namespace svg {
 
-void SvgPath::setD(std::string _d) {
-    d = _d;
+void SvgPath::setD(const std::string &d) {
+    d_ = d;
+    std::replace(d_.begin(), d_.end(), ',', ' ');
     PathParserUtils parser;
     parser.mScale = scale_;
     // only parser "d" to record the point info
@@ -45,7 +46,7 @@ drawing::Path SvgPath::AsPath() {
     */
     //TODO scale canvas? need to pass canvas in AsPath()
     matrix.SetMatrix(scale_, 0, 0, 0, scale_, 0, 0, 0, 1.0);
-    auto path = drawing::Path::BuildFromSvgString(d.c_str());
+    auto path = drawing::Path::BuildFromSvgString(d_.c_str());
     if (path.has_value()) {
         path_ = std::move(path.value());
         path_.Transform(matrix);

--- a/tester/harmony/svg/src/main/cpp/SvgPath.h
+++ b/tester/harmony/svg/src/main/cpp/SvgPath.h
@@ -5,13 +5,13 @@ namespace rnoh {
 namespace svg {
 class SvgPath : public SvgGraphic {
     private:
-        std::string d;
+        std::string d_;
 
     public:
         SvgPath() = default;
         ~SvgPath() override = default;
 
-        void setD(std::string d);
+        void setD(const std::string &d);
 
         drawing::Path AsPath() override;
 };

--- a/tester/svgDemoCases/components/IssueFix.tsx
+++ b/tester/svgDemoCases/components/IssueFix.tsx
@@ -73,15 +73,26 @@ class Issue178 extends Component {
           d="M0,61.14285714285714L26.725274222237722,97.71428571428572L53.450548444475444,70.28571428571428L80.17582266671316,20L106.90109688895089,110.51428571428572L133.62637111118863,128.79999999999998L160.35164533342632,29.142857142857146L187.07691955566406,23.657142857142865L213.80219377790178,74.85714285714286L240.52746800013952,58.39999999999999L267.25274222237726,155.31428571428572L293.9780164446149,84.91428571428571L320.70329066685264,61.14285714285714L347.4285648890904,125.14285714285715L374.1538391113281,180"
           fillOpacity={0}
           stroke="url(#gradient)"
-          strokeWidth="4"
-          >
-          </Path>
+          strokeWidth="4"></Path>
       </Svg>
     );
   }
 }
 
-const samples = [SvgLayoutExample, Issue178];
+class Issue185 extends Component {
+  static title = 'Stroke LinearGradient';
+  render() {
+    return (
+      <Svg style={{height: 200, width: 200}}>
+        <Path
+          d="M 5 2,h 154,q 3 0 3 3,v 164,q 0 3 -3 3,h -154,q -3 0 -3 -3,v -164,q 0 -3 3 -3"
+          fill="rgba(3,102,214,0.2)"></Path>
+      </Svg>
+    );
+  }
+}
+
+const samples = [SvgLayoutExample, Issue178, Issue185,];
 
 const styles = StyleSheet.create({
   container: {
@@ -107,6 +118,9 @@ export default function () {
         </TestCase>
         <TestCase itShould="Issue#178: Stroke color should have linear gradient">
           <Issue178 />
+        </TestCase>
+        <TestCase itShould="Issue #185: The <Path d='M 5 2,h 154,q 3 0 3 3,v 164,q 0 3 -3 3,h -154,q -3 0 -3 -3,v -164,q 0 -3 3 -3'> should draw properly">
+          <Issue185 />
         </TestCase>
       </ScrollView>
     </Tester>


### PR DESCRIPTION
# Summary
fix: Path fails to display correctly when there is a comma before the path commands in the 'd' attribute.

# Test Plan
Test is available in svgDemoCases IssueFix section as Issue#185

Resolve [#183](https://github.com/react-native-oh-library/react-native-harmony-svg/issues/183), [#185](https://github.com/react-native-oh-library/react-native-harmony-svg/issues/185)