### PR TITLE
fix:Gradient deal with fill rule

### DIFF
--- a/tester/harmony/svg/src/main/cpp/SvgGraphic.cpp
+++ b/tester/harmony/svg/src/main/cpp/SvgGraphic.cpp
@@ -179,8 +179,8 @@ bool SvgGraphic::UpdateFillStyle(bool antiAlias) {
         return SetPatternStyle();
     } else {
         fillBrush_.SetColor(fillState_.GetColor().BlendOpacity(curOpacity).GetValue());
-        path_.SetFillType(fillState_.GetFillRuleForDraw());
     }
+    path_.SetFillType(fillState_.GetFillRuleForDraw());
     return true;
 }
 void SvgGraphic::SetFillGradientStyle(double opacity) {


### PR DESCRIPTION
# Summary
fix: Gradient deal with fill rule

# Test Plan
Test is available in svgDemoCases IssueFix section as Issue#193

Resolve [#193](https://github.com/react-native-oh-library/react-native-harmony-svg/issues/193)