### PR TITLE
fix: support percentage input in SvgMask

### DIFF
--- a/tester/harmony/svg/src/main/cpp/SvgMask.cpp
+++ b/tester/harmony/svg/src/main/cpp/SvgMask.cpp
@@ -15,21 +15,26 @@
 
 #include "SvgMask.h"
 #include "drawing/Brush.h"
+#include <native_drawing/drawing_color_filter.h>
+#include <native_drawing/drawing_filter.h>
+#include <native_drawing/drawing_canvas.h>
+#include <native_drawing/drawing_color.h>
 
 namespace rnoh {
 namespace svg {
 
 void SvgMask::OnDrawTraversedBefore(OH_Drawing_Canvas *canvas) {
     LOG(INFO) << "[RNSVGMask] OnDrawTraversedBefore";
+    // TODO implement proper support for units
     auto nodeBounds = AsBounds();
     LOG(INFO) << "[RNSVGMask] Left0: " << nodeBounds.Left();
     LOG(INFO) << "[RNSVGMask] Top0: " << nodeBounds.Top();
     LOG(INFO) << "[RNSVGMask] Width0: " << nodeBounds.Width();
     LOG(INFO) << "[RNSVGMask] Height0: " << nodeBounds.Height();
-    auto left = static_cast<float>(nodeBounds.Left() + ParseUnitsAttr(x_, nodeBounds.Width()));
-    auto top = static_cast<float>(nodeBounds.Top() + ParseUnitsAttr(y_, nodeBounds.Height()));
-    auto width = static_cast<float>(ParseUnitsAttr(width_, nodeBounds.Width()));
-    auto height = static_cast<float>(ParseUnitsAttr(height_, nodeBounds.Height()));
+    auto left = static_cast<float>(nodeBounds.Left() + ParseUnitsAttr(maskAttribute_.x, nodeBounds.Width()));
+    auto top = static_cast<float>(nodeBounds.Top() + ParseUnitsAttr(maskAttribute_.y, nodeBounds.Height()));
+    auto width = static_cast<float>(ParseUnitsAttr(maskAttribute_.width, nodeBounds.Width()));
+    auto height = static_cast<float>(ParseUnitsAttr(maskAttribute_.height, nodeBounds.Height()));
     drawing::Rect maskBounds(left, top, width + left, height + top);
     maskBounds_ = maskBounds;
 
@@ -65,12 +70,18 @@ void SvgMask::OnDrawTraversedAfter(OH_Drawing_Canvas *canvas) {
 void SvgMask::OnInitStyle() { LOG(INFO) << "[RNSVGMask] OnInitStyle"; }
 
 double SvgMask::ParseUnitsAttr(const Dimension &attr, double value) {
-    LOG(INFO) << "[RNSVGMask] ParseUnitsAttr";
+    if (isDefaultMaskUnits_) {
+        // only support decimal or percent
+        if (attr.Unit() == DimensionUnit::PERCENT) {
+            return value * attr.Value();
+        }
+        return attr.Value() * value;
+    }
     // percent and px
     if (attr.Unit() == DimensionUnit::PERCENT) {
         return value * attr.Value();
     }
-    return attr.Value() * value;
+    return attr.Value();
 }
 
 } // namespace svg

--- a/tester/harmony/svg/src/main/cpp/SvgMask.h
+++ b/tester/harmony/svg/src/main/cpp/SvgMask.h
@@ -13,19 +13,9 @@
  * limitations under the License.
  */
 
-#include <native_drawing/drawing_brush.h>
-#include <native_drawing/drawing_color_filter.h>
-#include <native_drawing/drawing_filter.h>
-#include <native_drawing/drawing_point.h>
-#include <native_drawing/drawing_canvas.h>
-#include <native_drawing/drawing_color.h>
-#include <native_drawing/drawing_path.h>
-#include <native_drawing/drawing_pen.h>
-#include <native_drawing/drawing_rect.h>
 #include "drawing/Rect.h"
 #include "properties/Dimension.h"
 #include "SvgQuote.h"
-#include "properties/Rect.h"
 
 namespace rnoh {
 namespace svg {
@@ -35,13 +25,21 @@ public:
     SvgMask() = default;
     ~SvgMask() override = default;
 
-    void setMaskX(Dimension x) { x_ = x; }
+    void setMaskX(const std::string &x) {
+        maskAttribute_.x = StringUtils::StringToDimensionWithUnit(x, defaultDimensionUnit_);
+    }
 
-    void setMaskY(Dimension y) { y_ = y; }
+    void setMaskY(const std::string &y) {
+        maskAttribute_.y = StringUtils::StringToDimensionWithUnit(y, defaultDimensionUnit_);
+    }
 
-    void setMaskHeight(Dimension height) { height_ = height; }
+    void setMaskHeight(const std::string &height) {
+        maskAttribute_.height = StringUtils::StringToDimensionWithUnit(height, defaultDimensionUnit_);
+    }
 
-    void setMaskWidth(Dimension width) { width_ = width; }
+    void setMaskWidth(const std::string &width) {
+        maskAttribute_.width = StringUtils::StringToDimensionWithUnit(width, defaultDimensionUnit_);
+    }
 
     void isDefaultMaskUnits(bool isDefaultMaskUnits) { isDefaultMaskUnits_ = isDefaultMaskUnits; }
 
@@ -49,6 +47,17 @@ public:
         isDefaultMaskContentUnits_ = isDefaultMaskContentUnits;
     }
 
+    void setMaskUnits(const int &maskUnits) {
+        maskAttribute_.maskUnits = ToUnit(maskUnits);
+        isDefaultMaskUnits(maskAttribute_.maskUnits == Unit::objectBoundingBox);
+    }
+
+    void setMaskContentUnits(const int &maskContentUnits) {
+        maskAttribute_.maskContentUnits = ToUnit(maskContentUnits);
+        isDefaultMaskContentUnits(maskAttribute_.maskContentUnits == Unit::userSpaceOnUse);
+    }
+
+    void SetAttrMaskUnits(int maskUnits);
 
 protected:
     void OnInitStyle() override;
@@ -57,15 +66,13 @@ protected:
     double ParseUnitsAttr(const Dimension &attr, double value);
 
 private:
-    Dimension x_ = Dimension(-0.1, DimensionUnit::PERCENT);     // x-axis default value
-    Dimension y_ = Dimension(-0.1, DimensionUnit::PERCENT);     // y-axis default value
-    Dimension height_ = Dimension(1.2, DimensionUnit::PERCENT); // masking area width default value
-    Dimension width_ = Dimension(1.2, DimensionUnit::PERCENT);  // masking area height default  value
     bool isDefaultMaskUnits_ = true;
     bool isDefaultMaskContentUnits_ = true;
+    SvgMaskAttribute maskAttribute_;
 
     drawing::Rect maskBounds_;
     int canvasLayerCount_ = -1;
+    DimensionUnit defaultDimensionUnit_ = DimensionUnit::PERCENT;
 };
 
 } // namespace svg

--- a/tester/harmony/svg/src/main/cpp/componentInstances/RNSVGBaseComponentInstance.h
+++ b/tester/harmony/svg/src/main/cpp/componentInstances/RNSVGBaseComponentInstance.h
@@ -14,9 +14,9 @@ public:
     RNSVGBaseComponentInstance(ComponentInstance::Context context) : CppComponentInstance<T>(std::move(context)) {}
 
     void onPropsChanged(typename CppComponentInstance<T>::SharedConcreteProps const &props) override {
-        UpdateElementProps(props);
         GetSvgNode()->SetScale(CppComponentInstance<T>::m_layoutMetrics.pointScaleFactor);
         pointerEvents_ = props->pointerEvents.size() == 0 ? "auto" : props->pointerEvents;
+        UpdateElementProps(props);
         svgMarkDirty();
     }
     void onChildRemoved(ComponentInstance::Shared const &childComponentInstance) override {}

--- a/tester/harmony/svg/src/main/cpp/componentInstances/RNSVGMaskComponentInstance.cpp
+++ b/tester/harmony/svg/src/main/cpp/componentInstances/RNSVGMaskComponentInstance.cpp
@@ -22,12 +22,12 @@ void RNSVGMaskComponentInstance::UpdateElementProps(SharedConcreteProps const &p
     auto svgMask = std::dynamic_pointer_cast<SvgMask>(GetSvgNode());
     svgMask->UpdateCommonProps(props);
     // set attribute to svgMask.
-    svgMask->setMaskX(StringUtils::StringToDimension(props->x,true));
-    svgMask->setMaskY(StringUtils::StringToDimension(props->y,true));
-    svgMask->setMaskHeight(StringUtils::StringToDimension(props->height,true));
-    svgMask->setMaskWidth(StringUtils::StringToDimension(props->width,true));
-    svgMask->isDefaultMaskUnits(props->maskUnits == 0); // means objectBoundingBox
-    svgMask->isDefaultMaskContentUnits(props->maskContentUnits == 1);// means userSpaceOnUse
+    svgMask->setMaskUnits(props->maskUnits);
+    svgMask->setMaskContentUnits(props->maskContentUnits);
+    svgMask->setMaskX(props->x);
+    svgMask->setMaskY(props->y);
+    svgMask->setMaskHeight(props->height);
+    svgMask->setMaskWidth(props->width);
 }
 
 } // namespace svg

--- a/tester/harmony/svg/src/main/cpp/utils/SvgAttributesParser.h
+++ b/tester/harmony/svg/src/main/cpp/utils/SvgAttributesParser.h
@@ -125,8 +125,8 @@ struct SvgMaskAttribute {
     Dimension y = Dimension(-0.1, DimensionUnit::PERCENT); // y-axis default value
     Dimension width = Dimension(1.2, DimensionUnit::PERCENT); // masking area width default value
     Dimension height = Dimension(1.2, DimensionUnit::PERCENT); // masking area height default value
-    std::string maskContentUnits = "userSpaceOnUse";
-    std::string maskUnits = "objectBoundingBox";
+    Unit maskContentUnits = Unit::userSpaceOnUse;
+    Unit maskUnits = Unit::objectBoundingBox;
 };
 
 struct SvgCircleAttribute {

--- a/tester/svgDemoCases/components/IssueFix.tsx
+++ b/tester/svgDemoCases/components/IssueFix.tsx
@@ -17,6 +17,7 @@ import Svg, {
   Defs,
   LinearGradient,
   Stop,
+  SvgXml,
 } from 'react-native-svg';
 import {View, StyleSheet, ScrollView} from 'react-native';
 import {Tester, Filter, TestCase, TestSuite} from '@rnoh/testerino';
@@ -92,7 +93,32 @@ class Issue185 extends Component {
   }
 }
 
-const samples = [SvgLayoutExample, Issue178, Issue185,];
+class Issue193 extends Component {
+  static title = 'Mask with LinearGradient';
+  svgXml = `<svg width="240" height="240" viewBox="0 0 240 240" fill="none"
+  xmlns="http://www.w3.org/2000/svg">
+  <circle cx="120" cy="120" r="120" fill="#FFECDE"/>
+  <mask id="mask0_14651_25129" style="mask-type:alpha" maskUnits="userSpaceOnUse" x="0" y="0" width="240" height="240">
+  <rect width="240" height="240" rx="30" fill="#FF00DC"/>
+  </mask>
+  <g mask="url(#mask0_14651_25129)">
+  <path fill-rule="evenodd" clip-rule="evenodd" d="M57.1418 157.143C57.1418 169.767 67.3753 180 79.999 180H159.999C172.623 180 182.856 169.767 182.856 157.143V97.1429H57.1418V157.143ZM57.1419 85.7143H182.856L169.147 68.5784C164.81 63.1563 158.243 60 151.299 60H88.699C81.7554 60 75.1882 63.1563 70.8506 68.5784L57.1419 85.7143ZM82.2853 147.429C78.4982 147.429 75.4281 150.499 75.4281 154.286C75.4281 158.073 78.4982 161.143 82.2853 161.143H116.571C120.358 161.143 123.428 158.073 123.428 154.286C123.428 150.499 120.358 147.429 116.571 147.429H82.2853Z" fill="url(#paint0_linear_14651_25129)"/>
+  </g>
+  <defs>
+  <linearGradient id="paint0_linear_14651_25129" x1="57.1418" y1="180" x2="177.032" y2="54.4397" gradientUnits="userSpaceOnUse">
+  <stop stop-color="#FF003A"/>
+  <stop offset="1" stop-color="#FF0056"/>
+  </linearGradient>
+  </defs>
+  </svg>`;
+  render() {
+    return (
+      <SvgXml xml={this.svgXml} width={240} height={240} />
+    );
+  }
+}
+
+const samples = [SvgLayoutExample, Issue178, Issue185, Issue193,];
 
 const styles = StyleSheet.create({
   container: {
@@ -121,6 +147,9 @@ export default function () {
         </TestCase>
         <TestCase itShould="Issue #185: The <Path d='M 5 2,h 154,q 3 0 3 3,v 164,q 0 3 -3 3,h -154,q -3 0 -3 -3,v -164,q 0 -3 3 -3'> should draw properly">
           <Issue185 />
+        </TestCase>
+        <TestCase itShould="Issue #193: Box with window surrounded by circle">
+          <Issue193 />
         </TestCase>
       </ScrollView>
     </Tester>


### PR DESCRIPTION
# Summary
fix: SvgMask display incorrect.
test: add issue#193 demo.

# Test Plan
Test is available in svgDemoCases IssueFix section as Issue#193

Resolve [#193](https://github.com/react-native-oh-library/react-native-harmony-svg/issues/193)