### PR TITLE
refactor: use RNSVGImageShadowNode in source library

### DIFF
--- a/tester/harmony/svg/src/main/cpp/CMakeLists.txt
+++ b/tester/harmony/svg/src/main/cpp/CMakeLists.txt
@@ -10,6 +10,7 @@ file(GLOB rnoh_svg_SRC CONFIGURE_DEPENDS
     properties/*.cpp
     turboModules/*.cpp
     utils/*.cpp
+    svgImage/*.cpp
     )
 add_library(rnoh_svg SHARED ${rnoh_svg_SRC})
 target_include_directories(rnoh_svg PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})

--- a/tester/harmony/svg/src/main/cpp/ComponentDescriptors.h
+++ b/tester/harmony/svg/src/main/cpp/ComponentDescriptors.h
@@ -37,7 +37,6 @@ using RNSVGTextComponentDescriptor = ConcreteComponentDescriptor<RNSVGTextShadow
 using RNSVGTextPathComponentDescriptor = ConcreteComponentDescriptor<RNSVGTextPathShadowNode>;
 using RNSVGTSpanComponentDescriptor = ConcreteComponentDescriptor<RNSVGTSpanShadowNode>;
 using RNSVGUseComponentDescriptor = ConcreteComponentDescriptor<RNSVGUseShadowNode>;
-using RNSVGImageComponentDescriptor = ConcreteComponentDescriptor<RNSVGImageShadowNode>;
 
 } // namespace react
 } // namespace facebook

--- a/tester/harmony/svg/src/main/cpp/SVGPackage.cpp
+++ b/tester/harmony/svg/src/main/cpp/SVGPackage.cpp
@@ -49,6 +49,8 @@
 #include "componentBinders/RNSVGTextPathJSIBinder.h"
 #include "turboModules/RNSVGSvgViewModule.h"
 #include "turboModules/RNSVGRenderableModule.h"
+#include "ComponentDescriptors.h"
+#include "svgImage/RNSVGImageComponentDescriptor.h"
 
 using namespace rnoh;
 using namespace facebook;

--- a/tester/harmony/svg/src/main/cpp/SVGPackage.h
+++ b/tester/harmony/svg/src/main/cpp/SVGPackage.h
@@ -25,7 +25,6 @@
 #pragma once
 #include "RNOH/Package.h"
 #include <glog/logging.h>
-#include "ComponentDescriptors.h"
 #include "componentInstances/RNSVGSvgViewComponentInstance.h"
 #include "componentInstances/RNSVGCircleComponentInstance.h"
 #include "componentInstances/RNSVGGroupComponentInstance.h"

--- a/tester/harmony/svg/src/main/cpp/ShadowNodes.cpp
+++ b/tester/harmony/svg/src/main/cpp/ShadowNodes.cpp
@@ -34,7 +34,6 @@ extern const char RNSVGTextComponentName[] = "RNSVGText";
 extern const char RNSVGTextPathComponentName[] = "RNSVGTextPath";
 extern const char RNSVGTSpanComponentName[] = "RNSVGTSpan";
 extern const char RNSVGUseComponentName[] = "RNSVGUse";
-extern const char RNSVGImageComponentName[] = "RNSVGImage";
 
 } // namespace react
 } // namespace facebook

--- a/tester/harmony/svg/src/main/cpp/ShadowNodes.h
+++ b/tester/harmony/svg/src/main/cpp/ShadowNodes.h
@@ -250,13 +250,7 @@ using RNSVGUseShadowNode = ConcreteViewShadowNode<
     RNSVGUseEventEmitter,
     RNSVGUseState>;
 
-JSI_EXPORT extern const char RNSVGImageComponentName[];
 
-/*
- * `ShadowNode` for <RNSVGTSpan> component.
- */
-using RNSVGImageShadowNode =
-    ConcreteViewShadowNode<RNSVGImageComponentName, RNSVGImageProps, RNSVGImageEventEmitter, RNSVGImageState>;
 
 } // namespace react
 } // namespace facebook

--- a/tester/harmony/svg/src/main/cpp/States.h
+++ b/tester/harmony/svg/src/main/cpp/States.h
@@ -332,16 +332,6 @@ public:
 #endif
 };
 
-class RNSVGImageState {
-  public:
-  RNSVGImageState() = default;
-
-#ifdef ANDROID
-  RNSVGImageState(RNSVGImageState const &previousState, folly::dynamic data){};
-  folly::dynamic getDynamic() const { return {}; };
-  MapBuffer getMapBuffer() const { return MapBufferBuilder::EMPTY(); };
-#endif
-};
 
 } // namespace react
 } // namespace facebook

--- a/tester/harmony/svg/src/main/cpp/componentInstances/RNSVGImageComponentInstance.h
+++ b/tester/harmony/svg/src/main/cpp/componentInstances/RNSVGImageComponentInstance.h
@@ -25,6 +25,7 @@
 #pragma once
 
 #include "RNSVGBaseComponentInstance.h"
+#include "svgImage/RNSVGImageShadowNode.h"
 
 namespace rnoh {
 namespace svg {

--- a/tester/harmony/svg/src/main/cpp/svgImage/RNSVGImageComponentDescriptor.h
+++ b/tester/harmony/svg/src/main/cpp/svgImage/RNSVGImageComponentDescriptor.h
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <react/renderer/core/ConcreteComponentDescriptor.h>
+#include <react/renderer/imagemanager/ImageManager.h>
+#include <react/utils/ContextContainer.h>
+
+#include "RNSVGImageShadowNode.h"
+
+namespace facebook {
+namespace react {
+
+/*
+ * Descriptor for <RNSVGImage> component.
+ */
+class RNSVGImageComponentDescriptor final
+    : public ConcreteComponentDescriptor<RNSVGImageShadowNode> {
+ public:
+  RNSVGImageComponentDescriptor(ComponentDescriptorParameters const &parameters)
+      : ConcreteComponentDescriptor(parameters),
+        imageManager_(std::make_shared<ImageManager>(contextContainer_)){};
+
+  void adopt(ShadowNode::Unshared const &shadowNode) const override {
+    ConcreteComponentDescriptor::adopt(shadowNode);
+
+    auto imageShadowNode =
+        std::static_pointer_cast<RNSVGImageShadowNode>(shadowNode);
+
+    // `RNSVGImageShadowNode` uses `ImageManager` to initiate image loading and
+    // communicate the loading state and results to mounting layer.
+    imageShadowNode->setImageManager(imageManager_);
+  }
+
+ private:
+  const SharedImageManager imageManager_;
+};
+
+} // namespace react
+} // namespace facebook

--- a/tester/harmony/svg/src/main/cpp/svgImage/RNSVGImageShadowNode.cpp
+++ b/tester/harmony/svg/src/main/cpp/svgImage/RNSVGImageShadowNode.cpp
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <cstdlib>
+#include <limits>
+
+#include <react/renderer/core/LayoutContext.h>
+
+#include "RNSVGImageShadowNode.h"
+
+namespace facebook {
+namespace react {
+
+const char RNSVGImageComponentName[] = "RNSVGImage";
+
+void RNSVGImageShadowNode::setImageManager(
+    const SharedImageManager &imageManager) {
+  ensureUnsealed();
+  imageManager_ = imageManager;
+}
+
+ImageSource RNSVGImageShadowNode::getImageSource() const {
+  auto source = getConcreteProps().src;
+
+  auto layoutMetrics = getLayoutMetrics();
+  auto size = layoutMetrics.getContentFrame().size;
+  auto scale = layoutMetrics.pointScaleFactor;
+  source.size = size;
+  source.scale = scale;
+  return source;
+}
+
+void RNSVGImageShadowNode::updateStateIfNeeded() {
+  ensureUnsealed();
+
+  auto imageSource = getImageSource();
+  auto const &currentState = getStateData();
+  bool hasSameImageSource = currentState.getImageSource() == imageSource;
+
+  if (hasSameImageSource) {
+    return;
+  }
+
+  auto state = RNSVGImageState{
+      imageSource,
+      imageManager_->requestImage(imageSource, getSurfaceId()),
+  };
+  setStateData(std::move(state));
+}
+
+#pragma mark - LayoutableShadowNode
+
+void RNSVGImageShadowNode::layout(LayoutContext layoutContext) {
+  updateStateIfNeeded();
+  ConcreteViewShadowNode::layout(layoutContext);
+}
+
+} // namespace react
+} // namespace facebook

--- a/tester/harmony/svg/src/main/cpp/svgImage/RNSVGImageShadowNode.h
+++ b/tester/harmony/svg/src/main/cpp/svgImage/RNSVGImageShadowNode.h
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <jsi/jsi.h>
+#include <EventEmitters.h>
+#include <Props.h>
+#include <react/renderer/components/view/ConcreteViewShadowNode.h>
+#include <react/renderer/imagemanager/ImageManager.h>
+#include <react/renderer/imagemanager/primitives.h>
+
+#include "RNSVGImageState.h"
+
+namespace facebook {
+namespace react {
+
+JSI_EXPORT extern const char RNSVGImageComponentName[];
+
+/*
+ * `ShadowNode` for <RNSVGImage> component.
+ */
+class JSI_EXPORT RNSVGImageShadowNode final : public ConcreteViewShadowNode<
+                                                  RNSVGImageComponentName,
+                                                  RNSVGImageProps,
+                                                  ViewEventEmitter,
+                                                  RNSVGImageState> {
+ public:
+  using ConcreteViewShadowNode::ConcreteViewShadowNode;
+
+  static ShadowNodeTraits BaseTraits() {
+    auto traits = ConcreteViewShadowNode::BaseTraits();
+    traits.set(ShadowNodeTraits::Trait::LeafYogaNode);
+    return traits;
+  }
+
+  /*
+   * Associates a shared `ImageManager` with the node.
+   */
+  void setImageManager(const SharedImageManager &imageManager);
+
+  static RNSVGImageState initialStateData(
+      ShadowNodeFragment const &fragment,
+      ShadowNodeFamilyFragment const &familyFragment,
+      ComponentDescriptor const &componentDescriptor) {
+    auto imageSource = ImageSource{ImageSource::Type::Invalid};
+    return {imageSource, {imageSource, nullptr, {}}};
+  }
+
+#pragma mark - LayoutableShadowNode
+
+  void layout(LayoutContext layoutContext) override;
+
+ private:
+  ImageSource getImageSource() const;
+
+  SharedImageManager imageManager_;
+
+  void updateStateIfNeeded();
+};
+
+} // namespace react
+} // namespace facebook

--- a/tester/harmony/svg/src/main/cpp/svgImage/RNSVGImageState.cpp
+++ b/tester/harmony/svg/src/main/cpp/svgImage/RNSVGImageState.cpp
@@ -1,0 +1,21 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "RNSVGImageState.h"
+
+namespace facebook {
+namespace react {
+
+ImageSource RNSVGImageState::getImageSource() const {
+  return imageSource_;
+}
+
+ImageRequest const &RNSVGImageState::getImageRequest() const {
+  return *imageRequest_;
+}
+} // namespace react
+} // namespace facebook

--- a/tester/harmony/svg/src/main/cpp/svgImage/RNSVGImageState.h
+++ b/tester/harmony/svg/src/main/cpp/svgImage/RNSVGImageState.h
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <jsi/jsi.h>
+#include <react/renderer/imagemanager/ImageRequest.h>
+#include <react/renderer/imagemanager/primitives.h>
+
+#ifdef ANDROID
+#include <react/renderer/mapbuffer/MapBuffer.h>
+#include <react/renderer/mapbuffer/MapBufferBuilder.h>
+#endif
+
+namespace facebook {
+namespace react {
+
+/*
+ * State for <Image> component.
+ */
+class JSI_EXPORT RNSVGImageState final {
+ public:
+  RNSVGImageState(ImageSource const &imageSource, ImageRequest imageRequest)
+      : imageSource_(imageSource),
+        imageRequest_(
+            std::make_shared<ImageRequest>(std::move(imageRequest))){};
+
+  /*
+   * Returns stored ImageSource object.
+   */
+  ImageSource getImageSource() const;
+
+  /*
+   * Exposes for reading stored `ImageRequest` object.
+   * `ImageRequest` object cannot be copied or moved from `ImageLocalData`.
+   */
+  ImageRequest const &getImageRequest() const;
+
+#ifdef ANDROID
+  RNSVGImageState(RNSVGImageState const &previousState, folly::dynamic data){};
+
+  /*
+   * Empty implementation for Android because it doesn't use this class.
+   */
+  folly::dynamic getDynamic() const {
+    return {};
+  };
+
+  MapBuffer getMapBuffer() const {
+    return MapBufferBuilder::EMPTY();
+  };
+#endif
+
+ private:
+  ImageSource imageSource_;
+  std::shared_ptr<ImageRequest> imageRequest_;
+};
+
+} // namespace react
+} // namespace facebook


### PR DESCRIPTION
Use code in https://github.com/software-mansion/react-native-svg/tree/main/common/cpp/react/renderer/components/rnsvg

The source library doesn't use codegen to generate the cpp code of RNSVGImageShadowNode.