### PR TITLE
fix: clipPath display incorrect when using setState

### DIFF
--- a/tester/harmony/svg/src/main/cpp/SvgCircle.cpp
+++ b/tester/harmony/svg/src/main/cpp/SvgCircle.cpp
@@ -19,18 +19,19 @@ namespace rnoh {
 namespace svg {
 
 drawing::Path SvgCircle::AsPath() {
+    drawing::Path path;
     double x = relativeOnWidth(circleAttribute_.cx);
     double y = relativeOnHeight(circleAttribute_.cy);
     double r = relativeOnOther(circleAttribute_.r);
     
-    path_.AddCircle(x, y, r, PATH_DIRECTION_CW);
+    path.AddCircle(x, y, r, PATH_DIRECTION_CW);
     
     elements_ = {PathElement(ElementType::kCGPathElementMoveToPoint, {Point(x, y - r)}),
                        PathElement(ElementType::kCGPathElementAddLineToPoint, {Point(x, y - r), Point(x + r, y)}),
                        PathElement(ElementType::kCGPathElementAddLineToPoint, {Point(x + r, y), Point(x, y + r)}),
                        PathElement(ElementType::kCGPathElementAddLineToPoint, {Point(x, y + r), Point(x - r, y)}),
                        PathElement(ElementType::kCGPathElementAddLineToPoint, {Point(x - r, y), Point(x, y - r)})};
-    return path_;
+    return path;
 }
 
 } // namespace svg

--- a/tester/harmony/svg/src/main/cpp/SvgEllipse.cpp
+++ b/tester/harmony/svg/src/main/cpp/SvgEllipse.cpp
@@ -20,20 +20,21 @@ namespace rnoh {
 namespace svg {
 
 drawing::Path SvgEllipse::AsPath() {
+    drawing::Path path;
     double cx = relativeOnWidth(ellipseAttribute_.cx);
     double cy = relativeOnHeight(ellipseAttribute_.cy);
     double rx = relativeOnWidth(ellipseAttribute_.rx);
     double ry = relativeOnHeight(ellipseAttribute_.ry);
 
     drawing::Rect rect(cx - rx, cy - ry, cx + rx, cy + ry);
-    path_.AddOval(rect, PATH_DIRECTION_CW);
+    path.AddOval(rect, PATH_DIRECTION_CW);
 
     elements_ = {PathElement(ElementType::kCGPathElementMoveToPoint, {Point(cx, cy - ry)}),
                  PathElement(ElementType::kCGPathElementAddLineToPoint, {Point(cx, cy - ry), Point(cx + rx, cy)}),
                  PathElement(ElementType::kCGPathElementAddLineToPoint, {Point(cx + rx, cy), Point(cx, cy + ry)}),
                  PathElement(ElementType::kCGPathElementAddLineToPoint, {Point(cx, cy + ry), Point(cx - rx, cy)}),
                  PathElement(ElementType::kCGPathElementAddLineToPoint, {Point(cx - rx, cy), Point(cx, cy - ry)})};
-    return path_;
+    return path;
 };
 
 } // namespace svg

--- a/tester/harmony/svg/src/main/cpp/SvgLine.cpp
+++ b/tester/harmony/svg/src/main/cpp/SvgLine.cpp
@@ -4,17 +4,18 @@ namespace rnoh {
 namespace svg {
 
 drawing::Path SvgLine::AsPath() {
+    drawing::Path path;
     double x1 = relativeOnWidth(lineAttribute_.x1);
     double y1 = relativeOnHeight(lineAttribute_.y1);
     double x2 = relativeOnWidth(lineAttribute_.x2);
     double y2 = relativeOnHeight(lineAttribute_.y2);
 
-    path_.MoveTo(x1, y1);
-    path_.LineTo(x2, y2);
+    path.MoveTo(x1, y1);
+    path.LineTo(x2, y2);
     
     elements_ = {PathElement(ElementType::kCGPathElementMoveToPoint, {Point(x1, y1)}),
                  PathElement(ElementType::kCGPathElementAddLineToPoint, {Point(x2, y2)})};
-    return path_;
+    return path;
 };
 
 } // namespace svg

--- a/tester/harmony/svg/src/main/cpp/SvgPath.cpp
+++ b/tester/harmony/svg/src/main/cpp/SvgPath.cpp
@@ -40,6 +40,7 @@ void SvgPath::setD(const std::string &d) {
 
 drawing::Path SvgPath::AsPath() {
     drawing::Matrix matrix;
+    drawing::Path out;
     /*
     /* (OH_Drawing_Matrix* , float scaleX, float skewX, float transX, float skewY, float scaleY, float transY, float
     persp0, float persp1, float persp2 )
@@ -48,9 +49,9 @@ drawing::Path SvgPath::AsPath() {
     matrix.SetMatrix(scale_, 0, 0, 0, scale_, 0, 0, 0, 1.0);
     auto path = drawing::Path::BuildFromSvgString(d_.c_str());
     if (path.has_value()) {
-        path_ = std::move(path.value());
-        path_.Transform(matrix);
-        return path_;
+        out = std::move(path.value());
+        out.Transform(matrix);
+        return out;
     }
     return drawing::Path();
 }

--- a/tester/harmony/svg/src/main/cpp/SvgRect.cpp
+++ b/tester/harmony/svg/src/main/cpp/SvgRect.cpp
@@ -5,6 +5,7 @@ namespace rnoh {
 namespace svg {
 
 drawing::Path SvgRect::AsPath() {
+    drawing::Path path;
     double x = relativeOnWidth(rectAttribute_.x);
     double y = relativeOnHeight(rectAttribute_.y);
     double width = relativeOnWidth(rectAttribute_.width);
@@ -34,9 +35,9 @@ drawing::Path SvgRect::AsPath() {
         }
         drawing::Rect rect(x, y, x + width, y + height);
         drawing::RoundRect roundRect(std::move(rect), rx, ry);
-        path_.AddRoundRect(roundRect, PATH_DIRECTION_CW);
+        path.AddRoundRect(roundRect, PATH_DIRECTION_CW);
     } else {
-        path_.AddRect(x, y, x + width, y + height, PATH_DIRECTION_CW);
+        path.AddRect(x, y, x + width, y + height, PATH_DIRECTION_CW);
     }
 
     elements_ = {PathElement(ElementType::kCGPathElementMoveToPoint, {Point(x, y)}),
@@ -44,7 +45,7 @@ drawing::Path SvgRect::AsPath() {
                  PathElement(ElementType::kCGPathElementAddLineToPoint, {Point(x + width, y + height)}),
                  PathElement(ElementType::kCGPathElementAddLineToPoint, {Point(x, y + height)}),
                  PathElement(ElementType::kCGPathElementAddLineToPoint, {Point(x, y)})};
-    return path_;
+    return path;
 };
 
 } // namespace svg

--- a/tester/harmony/svg/src/main/cpp/componentInstances/RNSVGClipPathComponentInstance.h
+++ b/tester/harmony/svg/src/main/cpp/componentInstances/RNSVGClipPathComponentInstance.h
@@ -35,6 +35,10 @@ public:
     RNSVGClipPathComponentInstance(Context context);
 
     void UpdateElementProps(SharedConcreteProps const &props) override;
+
+    void onChildRemoved(ComponentInstance::Shared const &childComponentInstance) override {
+        OnChildRemoveCommon(std::dynamic_pointer_cast<SvgHost>(childComponentInstance));
+    }
 };
 
 } // namespace svg


### PR DESCRIPTION
# Summary
Fix the issue of clipPath will display incorrectly when using setState.

# Test Plan
Test is available in svgDemoCases ComplexDemo section as "Clip Image".

Resolve [#226 ](https://github.com/react-native-oh-library/react-native-harmony-svg/issues/226)