### PR TITLE
feat: SvgImage support online image sources

### DIFF
--- a/react-native-harmony-svg/src/elements/Image.tsx
+++ b/react-native-harmony-svg/src/elements/Image.tsx
@@ -1,0 +1,107 @@
+import * as React from 'react';
+import type { ImageProps as RNImageProps, NativeMethods, ImageResolvedAssetSource } from 'react-native';
+import { Image } from 'react-native';
+import { alignEnum, meetOrSliceTypes } from 'react-native-svg/src/lib/extract/extractViewBox';
+import {
+  stringifyPropsForFabric,
+  withoutXY,
+} from 'react-native-svg/src/lib/extract/extractProps';
+import type { CommonPathProps, NumberProp } from 'react-native-svg/src/lib/extract/types';
+import Shape from './Shape';
+import RNSVGImage from 'react-native-svg/src/fabric/ImageNativeComponent';
+import RNSVGImageModule from '../fabric/NativeSvgImageModule';
+
+const spacesRegExp = /\s+/;
+
+export interface ImageProps extends CommonPathProps {
+  x?: NumberProp;
+  y?: NumberProp;
+  width?: NumberProp;
+  height?: NumberProp;
+  xlinkHref?: RNImageProps['source'] | string;
+  href?: RNImageProps['source'] | string;
+  preserveAspectRatio?: string;
+  opacity?: NumberProp;
+}
+
+export default class SvgImage extends Shape<ImageProps> {
+  static displayName = 'Image';
+
+  static defaultProps = {
+    x: 0,
+    y: 0,
+    width: 0,
+    height: 0,
+    preserveAspectRatio: 'xMidYMid meet',
+  };
+
+  constructor(props: ImageProps) {
+    super(props);
+    this.state = {
+      href: props.href || props.xlinkHref,
+    };
+  }
+
+  fetchBase64String = (href: string) => {
+    const src = !href
+      ? null
+      : Image.resolveAssetSource(
+        typeof href === 'string' ? { uri: href } : href
+      )
+    if (src) {
+      RNSVGImageModule.getBase64String(src.uri).then((res) => {
+        this.setState({ href: res });
+      }
+      ).catch((error) => {
+        console.error(`getBase64String error: ${error.message}`);
+      });
+    }
+
+  };
+
+  render() {
+    const { props } = this;
+    const {
+      preserveAspectRatio,
+      x,
+      y,
+      width,
+      height,
+      xlinkHref,
+      href = xlinkHref,
+    } = props;
+    const modes = preserveAspectRatio
+      ? preserveAspectRatio.trim().split(spacesRegExp)
+      : [];
+    const align = modes[0];
+    const meetOrSlice: 'meet' | 'slice' | 'none' | string | undefined =
+      modes[1];
+    const stringifiedImageProps = stringifyPropsForFabric({
+      x,
+      y,
+      width,
+      height,
+    });
+    const imageProps = {
+      ...stringifiedImageProps,
+      meetOrSlice: meetOrSliceTypes[meetOrSlice] || 0,
+      align: alignEnum[align] || 'xMidYMid',
+      src: !this.state.href
+        ? null
+        : Image.resolveAssetSource(
+          typeof this.state.href === 'string' ? { uri: this.state.href } : this.state.href
+        ),
+    };
+    if (href && typeof href === 'string' && href.startsWith('http')) {
+      this.fetchBase64String(href);
+    }
+
+    return (
+      <RNSVGImage
+        ref={(ref) => this.refMethod(ref as (SvgImage & NativeMethods) | null)}
+        {...withoutXY(this, props)}
+        {...imageProps}
+      />
+    );
+  }
+}

--- a/react-native-harmony-svg/src/elements/Shape.tsx
+++ b/react-native-harmony-svg/src/elements/Shape.tsx
@@ -1,0 +1,345 @@
+/* eslint-disable @typescript-eslint/no-var-requires */
+import { Component } from 'react';
+import SvgTouchableMixin from 'react-native-svg/src/lib/SvgTouchableMixin';
+import extractBrush from 'react-native-svg/src/lib/extract/extractBrush';
+import type { ColorValue, NativeMethods } from 'react-native';
+import { findNodeHandle } from 'react-native';
+import type {
+  ColumnMajorTransformMatrix,
+  TransformProps,
+} from 'react-native-svg/src/lib/extract/types';
+import type { Spec } from 'react-native-svg/src/fabric/NativeSvgRenderableModule';
+
+export interface SVGBoundingBoxOptions {
+  fill?: boolean;
+  stroke?: boolean;
+  markers?: boolean;
+  clipped?: boolean;
+}
+
+export interface DOMPointInit {
+  x?: number;
+  y?: number;
+  z?: number;
+  w?: number;
+}
+
+export interface Point {
+  x: number;
+  y: number;
+}
+
+export interface SVGPoint extends Point {
+  matrixTransform(matrix: Matrix): SVGPoint;
+}
+
+export interface Rect {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+}
+export type SVGRect = Rect;
+
+export interface Matrix {
+  a: number;
+  b: number;
+  c: number;
+  d: number;
+  e: number;
+  f: number;
+}
+
+export interface SVGMatrix extends Matrix {
+  multiply(secondMatrix: Matrix): SVGMatrix;
+  inverse(): SVGMatrix;
+  translate(x: number, y: number): SVGMatrix;
+  scale(scaleFactor: number): SVGMatrix;
+  scaleNonUniform(scaleFactorX: number, scaleFactorY: number): SVGMatrix;
+  rotate(angle: number): SVGMatrix;
+  rotateFromVector(x: number, y: number): SVGMatrix;
+  flipX(): SVGMatrix;
+  flipY(): SVGMatrix;
+  skewX(angle: number): SVGMatrix;
+  skewY(angle: number): SVGMatrix;
+}
+
+export function multiplyMatrices(l: Matrix, r: Matrix): Matrix {
+  const { a: al, b: bl, c: cl, d: dl, e: el, f: fl } = l;
+  const { a: ar, b: br, c: cr, d: dr, e: er, f: fr } = r;
+
+  const a = al * ar + cl * br;
+  const c = al * cr + cl * dr;
+  const e = al * er + cl * fr + el;
+  const b = bl * ar + dl * br;
+  const d = bl * cr + dl * dr;
+  const f = bl * er + dl * fr + fl;
+
+  return { a, c, e, b, d, f };
+}
+
+export function invert({ a, b, c, d, e, f }: Matrix): Matrix {
+  const n = a * d - b * c;
+  return {
+    a: d / n,
+    b: -b / n,
+    c: -c / n,
+    d: a / n,
+    e: (c * f - d * e) / n,
+    f: -(a * f - b * e) / n,
+  };
+}
+
+const deg2rad = Math.PI / 180;
+
+export class SVGMatrix implements SVGMatrix {
+  constructor(matrix?: Matrix) {
+    if (matrix) {
+      const { a, b, c, d, e, f } = matrix;
+      this.a = a;
+      this.b = b;
+      this.c = c;
+      this.d = d;
+      this.e = e;
+      this.f = f;
+    } else {
+      this.a = 1;
+      this.b = 0;
+      this.c = 0;
+      this.d = 1;
+      this.e = 0;
+      this.f = 0;
+    }
+  }
+
+  multiply(secondMatrix: Matrix): SVGMatrix {
+    return new SVGMatrix(multiplyMatrices(this, secondMatrix));
+  }
+
+  inverse(): SVGMatrix {
+    return new SVGMatrix(invert(this));
+  }
+
+  translate(x: number, y: number): SVGMatrix {
+    return new SVGMatrix(
+      multiplyMatrices(this, { a: 1, b: 0, c: 0, d: 1, e: x, f: y })
+    );
+  }
+
+  scale(scaleFactor: number): SVGMatrix {
+    return new SVGMatrix(
+      multiplyMatrices(this, {
+        a: scaleFactor,
+        b: 0,
+        c: 0,
+        d: scaleFactor,
+        e: 0,
+        f: 0,
+      })
+    );
+  }
+
+  scaleNonUniform(scaleFactorX: number, scaleFactorY: number): SVGMatrix {
+    return new SVGMatrix(
+      multiplyMatrices(this, {
+        a: scaleFactorX,
+        b: 0,
+        c: 0,
+        d: scaleFactorY,
+        e: 0,
+        f: 0,
+      })
+    );
+  }
+
+  rotate(angle: number): SVGMatrix {
+    const cos = Math.cos(deg2rad * angle);
+    const sin = Math.sin(deg2rad * angle);
+    return new SVGMatrix(
+      multiplyMatrices(this, { a: cos, b: sin, c: -sin, d: cos, e: 0, f: 0 })
+    );
+  }
+
+  rotateFromVector(x: number, y: number): SVGMatrix {
+    const angle = Math.atan2(y, x);
+    const cos = Math.cos(deg2rad * angle);
+    const sin = Math.sin(deg2rad * angle);
+    return new SVGMatrix(
+      multiplyMatrices(this, { a: cos, b: sin, c: -sin, d: cos, e: 0, f: 0 })
+    );
+  }
+
+  flipX(): SVGMatrix {
+    return new SVGMatrix(
+      multiplyMatrices(this, { a: -1, b: 0, c: 0, d: 1, e: 0, f: 0 })
+    );
+  }
+
+  flipY(): SVGMatrix {
+    return new SVGMatrix(
+      multiplyMatrices(this, { a: 1, b: 0, c: 0, d: -1, e: 0, f: 0 })
+    );
+  }
+
+  skewX(angle: number): SVGMatrix {
+    return new SVGMatrix(
+      multiplyMatrices(this, {
+        a: 1,
+        b: 0,
+        c: Math.tan(deg2rad * angle),
+        d: 1,
+        e: 0,
+        f: 0,
+      })
+    );
+  }
+
+  skewY(angle: number): SVGMatrix {
+    return new SVGMatrix(
+      multiplyMatrices(this, {
+        a: 1,
+        b: Math.tan(deg2rad * angle),
+        c: 0,
+        d: 1,
+        e: 0,
+        f: 0,
+      })
+    );
+  }
+}
+
+export function matrixTransform(matrix: Matrix, point: Point): Point {
+  const { a, b, c, d, e, f } = matrix;
+  const { x, y } = point;
+  return {
+    x: a * x + c * y + e,
+    y: b * x + d * y + f,
+  };
+}
+
+export class SVGPoint implements SVGPoint {
+  constructor(point?: Point) {
+    if (point) {
+      const { x, y } = point;
+      this.x = x;
+      this.y = y;
+    } else {
+      this.x = 0;
+      this.y = 0;
+    }
+  }
+
+  matrixTransform(matrix: Matrix): SVGPoint {
+    return new SVGPoint(matrixTransform(matrix, this));
+  }
+}
+
+export const ownerSVGElement = {
+  createSVGPoint(): SVGPoint {
+    return new SVGPoint();
+  },
+  createSVGMatrix(): SVGMatrix {
+    return new SVGMatrix();
+  },
+};
+
+export default class Shape<P> extends Component<P, any> {
+  [x: string]: unknown;
+  root: (Shape<P> & NativeMethods) | null = null;
+  constructor(props: Readonly<P> | P) {
+    super(props);
+    SvgTouchableMixin(this);
+  }
+
+  refMethod: (instance: (Shape<P> & NativeMethods) | null) => void = (
+    instance: (Shape<P> & NativeMethods) | null
+  ) => {
+    this.root = instance;
+  };
+
+  // Hack to make Animated work with Shape components.
+  getNativeScrollRef(): (Shape<P> & NativeMethods) | null {
+    return this.root;
+  }
+
+  setNativeProps = (
+    props: P & {
+      matrix?: ColumnMajorTransformMatrix;
+      fill?: ColorValue;
+    } & TransformProps
+  ) => {
+    if (props.fill) {
+      // @ts-ignore TODO: native `fill` prop differs from the one passed in props
+      props.fill = extractBrush(props.fill);
+    }
+    this.root?.setNativeProps(props);
+  };
+
+  /*
+   * The following native methods are experimental and likely broken in some
+   * ways. If you have a use case for these, please open an issue with a
+   * representative example / reproduction.
+   * */
+  getBBox = (options?: SVGBoundingBoxOptions): SVGRect | undefined => {
+    const {
+      fill = true,
+      stroke = true,
+      markers = true,
+      clipped = true,
+    } = options || {};
+    const handle = findNodeHandle(this.root);
+    const RNSVGRenderableModule =
+      require('react-native-svg/src/fabric/NativeSvgRenderableModule').default;
+    return RNSVGRenderableModule.getBBox(handle, {
+      fill,
+      stroke,
+      markers,
+      clipped,
+    });
+  };
+
+  getCTM = (): SVGMatrix => {
+    const handle = findNodeHandle(this.root);
+    const RNSVGRenderableModule: Spec =
+      require('react-native-svg/src/fabric/NativeSvgRenderableModule').default;
+    return new SVGMatrix(RNSVGRenderableModule.getCTM(handle));
+  };
+
+  getScreenCTM = (): SVGMatrix => {
+    const handle = findNodeHandle(this.root);
+    const RNSVGRenderableModule: Spec =
+      require('react-native-svg/src/fabric/NativeSvgRenderableModule').default;
+    return new SVGMatrix(RNSVGRenderableModule.getScreenCTM(handle));
+  };
+
+  isPointInFill = (options: DOMPointInit): boolean | undefined => {
+    const handle = findNodeHandle(this.root);
+    const RNSVGRenderableModule: Spec =
+      require('react-native-svg/src/fabric/NativeSvgRenderableModule').default;
+    return RNSVGRenderableModule.isPointInFill(handle, options);
+  };
+
+  isPointInStroke = (options: DOMPointInit): boolean | undefined => {
+    const handle = findNodeHandle(this.root);
+    const RNSVGRenderableModule: Spec =
+      require('react-native-svg/src/fabric/NativeSvgRenderableModule').default;
+    return RNSVGRenderableModule.isPointInStroke(handle, options);
+  };
+
+  getTotalLength = (): number | undefined => {
+    const handle = findNodeHandle(this.root);
+    const RNSVGRenderableModule: Spec =
+      require('react-native-svg/src/fabric/NativeSvgRenderableModule').default;
+    return RNSVGRenderableModule.getTotalLength(handle);
+  };
+
+  getPointAtLength = (length: number): SVGPoint => {
+    const handle = findNodeHandle(this.root);
+    const RNSVGRenderableModule: Spec =
+      require('react-native-svg/src/fabric/NativeSvgRenderableModule').default;
+    return new SVGPoint(
+      RNSVGRenderableModule.getPointAtLength(handle, { length })
+    );
+  };
+}
+Shape.prototype.ownerSVGElement = ownerSVGElement;

--- a/react-native-harmony-svg/src/fabric/NativeSvgImageModule.ts
+++ b/react-native-harmony-svg/src/fabric/NativeSvgImageModule.ts
@@ -1,0 +1,10 @@
+/* eslint-disable @typescript-eslint/ban-types */
+// its needed for codegen to work
+import type { TurboModule } from 'react-native';
+import { TurboModuleRegistry } from 'react-native';
+
+export interface Spec extends TurboModule {
+  getBase64String(uri: string): Promise<string>;
+}
+
+export default TurboModuleRegistry.get<Spec>('RNSVGImageModule')!;

--- a/tester/harmony/svg/src/main/cpp/SVGPackage.cpp
+++ b/tester/harmony/svg/src/main/cpp/SVGPackage.cpp
@@ -49,6 +49,7 @@
 #include "componentBinders/RNSVGTextPathJSIBinder.h"
 #include "turboModules/RNSVGSvgViewModule.h"
 #include "turboModules/RNSVGRenderableModule.h"
+#include "turboModules/RNSVGImageModule.h"
 #include "ComponentDescriptors.h"
 #include "svgImage/RNSVGImageComponentDescriptor.h"
 
@@ -122,6 +123,9 @@ public:
         }
         if (name == "RNSVGRenderableModule") {
             return std::make_shared<RNSVGRenderableModule>(ctx, name);
+        }
+        if (name == "RNSVGImageModule") {
+            return std::make_shared<RNSVGImageModule>(ctx, name);
         }
         return nullptr;
     };

--- a/tester/harmony/svg/src/main/cpp/SvgImage.cpp
+++ b/tester/harmony/svg/src/main/cpp/SvgImage.cpp
@@ -52,7 +52,13 @@ void SvgImage::OnDraw(OH_Drawing_Canvas *canvas) {
         DLOG(INFO) << "[SvgImage] code: " << createPixelmapStatus;
 
         if (createPixelmapStatus == IMAGE_SUCCESS) {
-            OH_PixelmapNative_Opacity(pixelMap, attributes_.opacity);
+            /* Temporarily disable the feature to set opacity.
+             * Currently, there is an issue where setting opacity on 
+             * transparent pixels results in them turning black.
+             */
+            if (LessNotEqual(attributes_.opacity, 1.0f)) {
+                OH_PixelmapNative_Opacity(pixelMap, attributes_.opacity);
+            }
 
             // get the real width and height from pixelmap(OH_PixelmapNative *).
             OH_Pixelmap_ImageInfo *info;

--- a/tester/harmony/svg/src/main/cpp/turboModules/RNSVGImageModule.cpp
+++ b/tester/harmony/svg/src/main/cpp/turboModules/RNSVGImageModule.cpp
@@ -1,0 +1,13 @@
+#include "RNSVGImageModule.h"
+
+using namespace rnoh;
+using namespace facebook;
+
+RNSVGImageModule::RNSVGImageModule(
+    const ArkTSTurboModule::Context ctx,
+    const std::string name)
+    : ArkTSTurboModule(ctx, name) {
+    methodMap_ = {
+        ARK_ASYNC_METHOD_METADATA(getBase64String, 1),
+    };
+}

--- a/tester/harmony/svg/src/main/cpp/turboModules/RNSVGImageModule.h
+++ b/tester/harmony/svg/src/main/cpp/turboModules/RNSVGImageModule.h
@@ -1,0 +1,13 @@
+#pragma once
+
+#include <ReactCommon/TurboModule.h>
+#include "RNOH/ArkTSTurboModule.h"
+
+namespace rnoh {
+
+class JSI_EXPORT RNSVGImageModule : public ArkTSTurboModule {
+public:
+    RNSVGImageModule(const ArkTSTurboModule::Context ctx, const std::string name);
+};
+
+} // namespace rnoh

--- a/tester/harmony/svg/src/main/ets/Logger.ts
+++ b/tester/harmony/svg/src/main/ets/Logger.ts
@@ -1,0 +1,40 @@
+import hilog from '@ohos.hilog';
+
+class Logger {
+  private domain: number;
+  private prefix: string;
+  private format: string = '%{public}s, %{public}s';
+  private isDebug: boolean;
+
+  /**
+   * constructor.
+   *
+   * @param Prefix Identifies the log tag.
+   * @param domain Domain Indicates the service domain, which is a hexadecimal integer ranging from 0x0 to 0xFFFFF.
+   */
+  constructor(prefix: string = 'MyApp', domain: number = 0xFF00, isDebug = false) {
+    this.prefix = prefix;
+    this.domain = domain;
+    this.isDebug = isDebug;
+  }
+
+  debug(...args: string[]): void {
+    if(this.isDebug) {
+      hilog.debug(this.domain, this.prefix, this.format, args);
+    }
+  }
+
+  info(...args: string[]): void {
+    hilog.info(this.domain, this.prefix, this.format, args);
+  }
+
+  warn(...args: string[]): void {
+    hilog.warn(this.domain, this.prefix, this.format, args);
+  }
+
+  error(...args: string[]): void {
+    hilog.error(this.domain, this.prefix, this.format, args);
+  }
+}
+
+export default new Logger('RNSVG', 0xFF00, false)

--- a/tester/harmony/svg/src/main/ets/RNSVGImageModule.ts
+++ b/tester/harmony/svg/src/main/ets/RNSVGImageModule.ts
@@ -1,0 +1,72 @@
+import { TurboModule } from "@rnoh/react-native-openharmony/ts";
+import { BusinessError } from '@ohos.base';
+import image from '@ohos.multimedia.image';
+import http from '@ohos.net.http';
+import ResponseCode from '@ohos.net.http';
+import buffer from '@ohos.buffer';
+import Logger from './Logger'
+
+export class RNSVGImageModule extends TurboModule {
+  pixelMap: image.PixelMap | undefined = undefined
+
+  public static readonly NAME = 'RNSVGImageModule';
+
+  async getBase64String(uri: string): Promise<string> {
+    if (uri.startsWith('data:')) {
+      return Promise.resolve(uri);
+    }
+    let image: image.PixelMap | undefined = undefined;
+    try {
+      if (uri.includes('http')) {
+        image = await this.getPixelMapFromURL(uri);
+      } else {
+        //TODO get pixelMap from local uri
+      }
+      if (image === undefined) {
+        let message = "Error! Failed to decode Bitmap, uri: " + uri;
+        Logger.warn(message);
+        return Promise.reject(message);
+      } else {
+        return Promise.resolve(this.pixelMapToBase64(image));
+      }
+    } catch (error) {
+      let message = "Error! Failed to decode pixelMap: " + error.message;
+      Logger.warn(message);
+      Promise.reject(message);
+    }
+  }
+
+  async getPixelMapFromURL(src: string): Promise<image.PixelMap> {
+    let pixelMap: image.PixelMap | undefined = undefined;
+    let data = await http.createHttp().request(src);
+    if (data.responseCode == ResponseCode.ResponseCode.OK && data.result instanceof ArrayBuffer) {
+      let imageData: ArrayBuffer = data.result;
+      let imageSource: image.ImageSource = image.createImageSource(imageData);
+      let imageInfo = await imageSource.getImageInfo();
+      let imageWidth = Math.round(imageInfo.size.width);
+      let imageHeight = Math.round(imageInfo.size.height);
+      let options: image.InitializationOptions = {
+        alphaType: 1,
+        editable: false,
+        pixelFormat: 3,
+        scaleMode: 1,
+        size: { width: imageWidth, height: imageHeight }
+      };
+      pixelMap = await imageSource.createPixelMap(options);
+    }
+    return pixelMap;
+  }
+
+  async pixelMapToBase64(pixelMap: image.PixelMap): Promise<string> {
+    let base64Url: string = '';
+    let imagePacker = image.createImagePacker();
+    let packOptions: image.PackingOption = { format: "image/png", quality: 100 };
+    let data: ArrayBuffer = await imagePacker.packing(pixelMap, packOptions);
+    if (data) {
+      let buf: buffer.Buffer = buffer.from(data);
+      base64Url = buf.toString('base64', 0, buf.length);
+      Logger.debug(`svgImage base64: data:image/png;base64,${base64Url}`);
+    }
+    return "data:image/png;base64," + base64Url;
+  }
+}

--- a/tester/harmony/svg/src/main/ets/SvgPackage.ts
+++ b/tester/harmony/svg/src/main/ets/SvgPackage.ts
@@ -2,6 +2,7 @@ import { RNPackage, TurboModulesFactory } from '@rnoh/react-native-openharmony/t
 import type { TurboModule, TurboModuleContext } from '@rnoh/react-native-openharmony/ts';
 import { RNSVGSvgViewModule } from './RNSVGSvgViewModule';
 import { RNSVGRenderableModule } from './RNSVGRenderableModule';
+import { RNSVGImageModule } from './RNSVGImageModule';
 
 class SvgTurboModulesFactory extends TurboModulesFactory {
   createTurboModule(name: string): TurboModule | null {
@@ -11,11 +12,14 @@ class SvgTurboModulesFactory extends TurboModulesFactory {
     if (name === 'RNSVGRenderableModule') {
       return new RNSVGRenderableModule(this.ctx);
     }
+    if (name === 'RNSVGImageModule') {
+      return new RNSVGImageModule(this.ctx);
+    }
     return null;
   }
 
   hasTurboModule(name: string): boolean {
-    return name === 'RNSVGSvgViewModule' || name === 'RNSVGRenderableModule';
+    return name === 'RNSVGSvgViewModule' || name === 'RNSVGRenderableModule' || name === 'RNSVGImageModule';
   }
 }
 

--- a/tester/svgDemoCases/components/Image.tsx
+++ b/tester/svgDemoCases/components/Image.tsx
@@ -66,8 +66,7 @@ const basicCases: CaseParams[] = [
             {
                 width:90,
                 height: 60,
-                fill: 'red',
-                xlinkHref: "https://img.icons8.com/2266EE/search"
+                href: 'https://live.mdnplay.dev/zh-CN/docs/Web/SVG/Element/image/mdn_logo_only_color.png',
             }
         ]
     },


### PR DESCRIPTION
# Summary
In CAPI, as there is no API for managing network resource downloads, it is necessary to use Turbomodule on the ArkTS side to download images, convert them to base64, and then pass them to SvgImage.


# Test Plan
Test is available in svgDemoCases Image section.

Resolve [#222 ](https://github.com/react-native-oh-library/react-native-harmony-svg/issues/222)