### PR TITLE
feat: move css to different package for size reduction same as source…

### DIFF
--- a/react-native-harmony-svg/css/package.json
+++ b/react-native-harmony-svg/css/package.json
@@ -1,0 +1,6 @@
+{
+    "main": "../lib/commonjs/css/index",
+    "module": "../lib/module/css/index",
+    "react-native": "../src/css/index",
+    "types": "../lib/typescript/css/index"
+  }

--- a/react-native-harmony-svg/package.json
+++ b/react-native-harmony-svg/package.json
@@ -35,6 +35,7 @@
     "harmony",
     "src",
     "lib",
+    "css",
     "./*.json"
   ],
   "react-native-builder-bob": {

--- a/react-native-harmony-svg/src/css/index.tsx
+++ b/react-native-harmony-svg/src/css/index.tsx
@@ -1,0 +1,20 @@
+import {
+    SvgCss,
+    SvgCssUri,
+    SvgWithCss,
+    SvgWithCssUri,
+    inlineStyles,
+  } from 'react-native-svg/css';
+  
+  import { LocalSvg, WithLocalSvg, loadLocalRawResource } from 'react-native-svg/css';
+  
+  export {
+    SvgCss,
+    SvgCssUri,
+    SvgWithCss,
+    SvgWithCssUri,
+    inlineStyles,
+    LocalSvg,
+    WithLocalSvg,
+    loadLocalRawResource,
+  };

--- a/react-native-harmony-svg/src/index.tsx
+++ b/react-native-harmony-svg/src/index.tsx
@@ -1,3 +1,3 @@
-import Svg from "react-native-svg"
-export * from "react-native-svg"
-export default Svg
+export * from 'react-native-svg/src/ReactNativeSVG';
+
+export { default } from 'react-native-svg/src/ReactNativeSVG';

--- a/tester/svgDemoCases/components/ComplexDemo.tsx
+++ b/tester/svgDemoCases/components/ComplexDemo.tsx
@@ -20,7 +20,15 @@ import Svg, {
   Stop,
   ClipPath,
 } from 'react-native-svg';
-import {View, StyleSheet, ScrollView, Alert} from 'react-native';
+import {SvgCssUri} from 'react-native-svg/css';
+import {
+  View,
+  StyleSheet,
+  ScrollView,
+  Alert,
+  Button,
+  Text as RNText,
+} from 'react-native';
 import {Tester, Filter, TestCase, TestSuite} from '@rnoh/testerino';
 import {TestItem} from './gen';
 
@@ -433,6 +441,49 @@ class ClipImage extends Component {
   }
 }
 
+const URIs = {
+  invalid: 'https://en.wikipedia.org/wiki/File:Vector-based_example.svg',
+  valid:
+    'https://pixabay.com/get/g9bea6c6d0895a4b46db7e4627b0deb1d799a786a9f14ed733bb254dac4f069edad2b4b4c1a9e8c4b70d6e15b6e0e2da0.svg',
+};
+
+class SvgCssExample extends Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      uri: URIs.invalid,
+    };
+  }
+
+  handlePress = () => {
+    const {uri} = this.state;
+    const newUri = uri === URIs.valid ? URIs.invalid : URIs.valid;
+    this.setState({uri: newUri});
+  };
+
+  render() {
+    const {uri} = this.state;
+    const title =
+      uri === URIs.invalid
+        ? 'Render fallback due to invalid SVG'
+        : 'Render Valid SVG';
+
+    const buttonTitle = `Switch to ${
+      uri === URIs.invalid ? 'valid' : 'invalid'
+    } SVG`;
+
+    return (
+      <View style={{flex: 1, justifyContent: 'center', alignItems: 'center'}}>
+        <RNText>{title}</RNText>
+        <View style={{paddingVertical: 20}}>
+          <SvgCssUri onError={() => {}} uri={uri} width={200} height={200} />
+        </View>
+        <Button onPress={this.handlePress} title={buttonTitle} />
+      </View>
+    );
+  }
+}
+
 const samples = [
   LinearGradientExample,
   HuaweiPathExample,
@@ -443,6 +494,7 @@ const samples = [
   GExample,
   ImageExample,
   ClipImage,
+  SvgCssExample,
 ];
 
 const styles = StyleSheet.create({
@@ -493,6 +545,9 @@ export default function () {
         </TestCase>
         <TestCase itShould="Clip Image">
           <ClipImage />
+        </TestCase>
+        <TestCase itShould="Show svg from valid uri">
+          <SvgCssExample />
         </TestCase>
       </ScrollView>
     </Tester>


### PR DESCRIPTION
As https://github.com/software-mansion/react-native-svg/issues/1264 bug report explains, The bundle size increased drastically from version 9.11.1 to 11.0.1+. It has climbed from 55kb to 173kb. This significant increase occurred due to css-tree library.

This PR makes css-tree and all css related code optional. All CSS related functions, component, etc exports. have been moved out from the src/index.ts into css/index.ts. It makes possible to use the latest SVG improvement, features without huge bundle size change. For using CSS related code, it is needed to be imported separately e.g.

***THIS IS A BREAKING CHANGE***. From now on, you should import 
```
  SvgCss,
  SvgCssUri,
  SvgWithCss,
  SvgWithCssUri,
  inlineStyles,
  LocalSvg,
  WithLocalSvg,
  loadLocalRawResource,
  ```
 from `react-native-svg/css` package instead.

see: https://github.com/software-mansion/react-native-svg/commit/2b030dda125439742cef84dcb7cbc5464deb6ba6