### PR TITLE
fix: SvgText alignmentBaseline invalid

### DIFF
--- a/tester/harmony/svg/src/main/cpp/SvgText.cpp
+++ b/tester/harmony/svg/src/main/cpp/SvgText.cpp
@@ -16,6 +16,12 @@ void SvgText::GlyphTraversal(OH_Drawing_Canvas *canvas) {
     for (auto const &child : children_) {
         if (auto span = std::dynamic_pointer_cast<TextBase>(child)) {
             span->SetGlyphContext(glyphCtx_);
+            if (!span->hasAlignmentBaseline()) {
+                span->setAlignmentBaseline(align_);
+            }
+            if (!span->hasBaselineShift()) {
+                span->setBaselineShift(baselineShift_);
+            }
         }
     }
 }

--- a/tester/harmony/svg/src/main/cpp/TextBase.h
+++ b/tester/harmony/svg/src/main/cpp/TextBase.h
@@ -44,6 +44,8 @@ public:
             textLength_ = StringUtils::FromString(props->textLength);
         }
 
+        hasBaselineShift_ = false;
+        hasAlign_ = false;
         if (!props->verticalAlign.empty()) {
             auto align = props->verticalAlign;
             align.erase(0, align.find_first_not_of(" \t\r\n"));
@@ -51,22 +53,36 @@ public:
             size_t i = align.find_last_of(' ');
             align_ = alignmentBaselineFromStr(align.substr(i));
             baselineShift_ = align.substr(0, i);
+            hasAlign_ = true;
+            hasBaselineShift_ = true;
         } else {
             align_ = AlignmentBaseline::baseline;
             baselineShift_.clear();
+            hasAlign_ = false;
+            hasBaselineShift_ = false;
         }
 
         if (!props->baselineShift.empty()) {
             baselineShift_ = props->baselineShift;
+            hasBaselineShift_ = true;
         }
         if (!props->alignmentBaseline.empty()) {
             align_ = alignmentBaselineFromStr(props->alignmentBaseline);
+            hasAlign_ = true;
         }
 
         lengthAdjust_ = textLengthAdjustFromStr(props->lengthAdjust);
     }
 
     void SetGlyphContext(const std::shared_ptr<GlyphContext> &ctx) { glyphCtx_ = ctx; }
+    
+    void setAlignmentBaseline(const AlignmentBaseline &alignmentBaseline) { align_ = alignmentBaseline; }
+    
+    bool hasAlignmentBaseline() { return hasAlign_; }
+    
+    void setBaselineShift(const std::string &baselineShift) { baselineShift_ = baselineShift; }
+    
+    bool hasBaselineShift() { return hasBaselineShift_; }
 
 protected:
     void InitGlyph(OH_Drawing_Canvas *canvas, double scale);
@@ -80,8 +96,10 @@ protected:
     std::optional<Dimension> textLength_;
 
     std::string baselineShift_;
+    bool hasBaselineShift_ = false;
     TextLengthAdjust lengthAdjust_ = TextLengthAdjust::spacing;
     AlignmentBaseline align_ = AlignmentBaseline::baseline;
+    bool hasAlign_ = false;
 
     std::shared_ptr<GlyphContext> glyphCtx_;
 };

--- a/tester/svgDemoCases/components/IssueFix.tsx
+++ b/tester/svgDemoCases/components/IssueFix.tsx
@@ -22,6 +22,7 @@ import Svg, {
 } from 'react-native-svg';
 import { View, StyleSheet, ScrollView, Text, Button, TouchableOpacity } from 'react-native';
 import { Tester, Filter, TestCase, TestSuite } from '@rnoh/testerino';
+import Issue241 from './issueTests/Issue241';
 
 class SvgLayoutExample extends Component {
   static title = 'SVG with flex layout';
@@ -333,6 +334,7 @@ const samples = [
   Issue203,
   Issue203Extend,
   Issue212,
+  Issue241,
 ];
 
 const styles = StyleSheet.create({
@@ -377,6 +379,9 @@ export default function () {
         </TestCase>
         <TestCase itShould="Issue #218: Mask should refresh when children remove">
           <Issue218 />
+        </TestCase>
+        <TestCase itShould="Issue #241: Text alignmentBaseline">
+          <Issue241 />
         </TestCase>
       </ScrollView>
     </Tester>

--- a/tester/svgDemoCases/components/issueTests/Issue241.tsx
+++ b/tester/svgDemoCases/components/issueTests/Issue241.tsx
@@ -1,0 +1,45 @@
+import React, {Component} from 'react';
+import {SvgXml} from 'react-native-svg';
+
+export default class Issue241 extends Component {
+  static title = 'Issues#241';
+  svgXml = `
+    <svg
+    width="300"
+    height="120"
+    viewBox="0 0 300 120"
+    xmlns="http://www.w3.org/2000/svg">
+    <!-- Materialization of anchors -->
+    <path
+      d="M60,10 L60,110
+                M30,10 L300,10
+                M30,65 L300,65
+                M30,110 L300,110
+                "
+      stroke="grey" />
+  
+    <!-- Anchors in action -->
+    <text alignment-baseline="hanging" x="60" y="10">A hanging</text>
+  
+    <text alignment-baseline="middle" x="60" y="65">A middle</text>
+  
+    <text alignment-baseline="baseline" x="60" y="110">A baseline</text>
+  
+    <!-- Materialization of anchors -->
+    <circle cx="60" cy="10" r="3" fill="red" />
+    <circle cx="60" cy="65" r="3" fill="red" />
+    <circle cx="60" cy="110" r="3" fill="red" />
+  
+    <style>
+      <![CDATA[
+        text{
+          font: bold 36px Verdana, Helvetica, Arial, sans-serif;
+        }
+      ]]>
+    </style>
+  </svg>
+  `;
+  render() {
+    return <SvgXml xml={this.svgXml} />;
+  }
+}


### PR DESCRIPTION
# Summary
TSpan's alignmentBaseline and baselineShift haven't been inherited from their parent, and the coordinate of typography hasn't been considered, leading to the invalid alignmentBaseline problem.

# Test Plan
Test is available in svgDemoCases IssueFix section as "Issue#241".

Resolve #239 , #241 , #240 