### PR TITLE
fix: Fix the Display error of fill attribute in text when using LinearGradient gradient

### DIFF
--- a/tester/harmony/svg/src/main/cpp/SvgGraphic.cpp
+++ b/tester/harmony/svg/src/main/cpp/SvgGraphic.cpp
@@ -111,9 +111,17 @@ void SvgGraphic::OnGraphicStroke(OH_Drawing_Canvas *canvas) {
 void SvgGraphic::UpdateGradient(std::optional<Gradient> &gradient) {
     CHECK_NULL_VOID(gradient);
     // objectBoundingBox - 0(DEFAULT), userSpaceOnUse - 1
-    auto nodeBounds = (gradient->GetGradientUnits() == Unit::objectBoundingBox)
-                          ? AsBounds()
-                          : Rect(0, 0, context_->GetSvgSize().Width(), context_->GetSvgSize().Height());
+    
+    Rect nodeBounds;
+    if (gradient->GetGradientUnits() == Unit::objectBoundingBox) {
+        nodeBounds = AsBounds();
+        if (nodeBounds.Width() == 0 && nodeBounds.Height() == 0) {
+            nodeBounds = Rect(0, 0, context_->GetSvgSize().Width(), context_->GetSvgSize().Height());
+        }
+    } else {
+        nodeBounds = Rect(0, 0, context_->GetSvgSize().Width(), context_->GetSvgSize().Height());
+    }
+
     if (gradient->GetType() == GradientType::LINEAR) {
         const auto &linearGradient = gradient->GetLinearGradient();
         auto gradientInfo = LinearGradientInfo();

--- a/tester/harmony/svg/src/main/cpp/SvgTSpan.cpp
+++ b/tester/harmony/svg/src/main/cpp/SvgTSpan.cpp
@@ -97,6 +97,7 @@ double SvgTSpan::getTextAnchorOffset(TextAnchor textAnchor, const double &textMe
 
 drawing::TypographyStyle SvgTSpan::PrepareTypoStyle() {
     UpdateStrokeStyle();
+    UpdateGradient(attributes_.fillState.GetGradient());
     auto fillOpaque = UpdateFillStyle();
     if (!fillOpaque) {
         fillBrush_.SetColor(Color::TRANSPARENT.GetValue());

--- a/tester/svgDemoCases/components/IssueFix.tsx
+++ b/tester/svgDemoCases/components/IssueFix.tsx
@@ -327,6 +327,31 @@ const Issue218 = React.memo((props: {}) => {
   );
 });
 
+
+export function Issue244 = React.memo((props: {}) => {
+  return (
+    <View >
+        <Svg height={50} width={28} >
+            <Defs>
+              <LinearGradient id="grad" x1="0%" y1="0%" x2="0%" y2="100%">
+                <Stop stopColor="yellow" offset="24.67%" stopOpacity={1} />
+                <Stop stopColor="red" offset="77.8%" stopOpacity={1} />
+              </LinearGradient>
+            </Defs>
+            <SVGText
+              fill="url(#grad)"
+              fontSize={"42"}
+              x="50%" 
+              y="60%"
+              textAnchor="middle"
+              alignmentBaseline="middle">
+              {'6'}
+            </SVGText>
+          </Svg>
+    </View>
+  );
+}
+
 const samples = [
   SvgLayoutExample,
   Issue178,
@@ -386,6 +411,9 @@ export default function () {
         </TestCase>
         <TestCase itShould="Issue #241: Text alignmentBaseline">
           <Issue241 />
+        </TestCase>
+        <TestCase itShould="Issue #244: Display error of fill attribute in text when using LinearGradient gradient">
+          <Issue244 />
         </TestCase>
       </ScrollView>
     </Tester>


### PR DESCRIPTION
## Summary
The UpdateGradient method is added to SvgTSpan, and an extra judgment is added to UpdateGradient to rectify the display exception of SVGText. 
In SvgGraphic::UpdateGradient getting the width and height data of the parent component sometimes gets invalid width and height data, so we added a data validation to make SvgGraphic work properly.
 
## Test Plan
Test is available in svgDemoCases IssueFix section as Issue#244

Resolve #244

