### PR TITLE
fix: SvgText does not display gradient fill effects

### DIFF
--- a/tester/harmony/svg/src/main/cpp/SvgNode.h
+++ b/tester/harmony/svg/src/main/cpp/SvgNode.h
@@ -117,7 +117,7 @@ public:
         attributes_.clipState.SetClipRule(static_cast<ClipState::ClipRule>(props->clipRule), true);
     }
 
-    Rect AsBounds();
+    virtual Rect AsBounds();
 
     void SetScale(const double &scale) { scale_ = scale; }
 

--- a/tester/harmony/svg/src/main/cpp/SvgTSpan.h
+++ b/tester/harmony/svg/src/main/cpp/SvgTSpan.h
@@ -30,6 +30,8 @@ public:
     double getTextAnchorOffset(TextAnchor textAnchor, const double &textMeasure);
     
     std::string content_;
+    
+    Rect AsBounds() override;
 
 private:
     void DrawTextPath(OH_Drawing_Canvas* canvas);
@@ -45,6 +47,11 @@ private:
     double CalcBaselineShift(OH_Drawing_TypographyCreate* handler, OH_Drawing_TextStyle* style, const OH_Drawing_Font_Metrics& fm);
 
     std::shared_ptr<SvgTextPath> textPath_;
+    
+    double boundsWidth_ = 0;
+    double boundsHeight_ = 0;
+    double boundsX_ = 0;
+    double boundsY_ = 0;
 };
 
 } // namespace svg

--- a/tester/harmony/svg/src/main/cpp/TextBase.h
+++ b/tester/harmony/svg/src/main/cpp/TextBase.h
@@ -2,7 +2,6 @@
 #include "utils/StringUtils.h"
 #include "utils/GlyphContext.h"
 #include "properties/TextProperties.h"
-#include "TextBase.h"
 #include <native_drawing/drawing_text_typography.h>
 #include <optional>
 

--- a/tester/svgDemoCases/components/IssueFix.tsx
+++ b/tester/svgDemoCases/components/IssueFix.tsx
@@ -24,6 +24,7 @@ import { View, StyleSheet, ScrollView, Text, Button, TouchableOpacity } from 're
 import { Tester, Filter, TestCase, TestSuite } from '@rnoh/testerino';
 import Issue241 from './issueTests/Issue241';
 import Issue236 from './issueTests/Issue236';
+import Issue244 from './issueTests/Issue244';
 
 class SvgLayoutExample extends Component {
   static title = 'SVG with flex layout';
@@ -336,6 +337,7 @@ const samples = [
   Issue203Extend,
   Issue212,
   Issue241,
+  Issue244,
 ];
 
 const styles = StyleSheet.create({
@@ -386,6 +388,9 @@ export default function () {
         </TestCase>
         <TestCase itShould="Issue #241: Text alignmentBaseline">
           <Issue241 />
+        </TestCase>
+        <TestCase itShould="Issue #244: Text linear gradient">
+          <Issue244 />
         </TestCase>
       </ScrollView>
     </Tester>

--- a/tester/svgDemoCases/components/issueTests/Issue244.tsx
+++ b/tester/svgDemoCases/components/issueTests/Issue244.tsx
@@ -1,0 +1,32 @@
+import * as React from 'react';
+import {View} from 'react-native';
+import Svg, {
+  Defs,
+  LinearGradient,
+  Stop,
+  Text as SvgText,
+} from 'react-native-svg';
+
+export default function Issue244() {
+  return (
+    <View style={{padding: 20}}>
+      <Svg height={200} width={330} style={{backgroundColor: 'blue'}}>
+        <Defs>
+          <LinearGradient id="grad" x1="0%" y1="0%" x2="0%" y2="100%">
+            <Stop stopColor="yellow" offset="24.67%" stopOpacity={1} />
+            <Stop stopColor="red" offset="77.8%" stopOpacity={1} />
+          </LinearGradient>
+        </Defs>
+        <SvgText
+          fill="url(#grad)"
+          fontSize={'42'}
+          x="50%"
+          y="60%"
+          textAnchor="middle"
+          alignmentBaseline="middle">
+          {'6xX'}
+        </SvgText>
+      </Svg>
+    </View>
+  );
+}


### PR DESCRIPTION
# Summary
Fix the issue of SvgText does not display gradient fill effects.

# Remaining Problems

Since HarmonyOS does not support `getTextPath` (SR20240517314970), we cannot dynamically obtain the actual bounds of the text content. For alphabetic text like 'Xj', this limitation results in incorrect gradient effects, as we are currently setting a fixed value for the height of the bound -- `Font_Metrics.capHeight`.
![image](https://github.com/react-native-oh-library/react-native-harmony-svg/assets/61399097/36d0a5e1-144e-4fdd-9500-a3a7d91759d6)

# Test Plan
Test is available in svgDemoCases IssueFix section as "Issue#244".

Resolve #244 