### PR TITLE
build: use JS script to generate build-profile.json5

### DIFF
--- a/tester/harmony/build-profile.template.json5
+++ b/tester/harmony/build-profile.template.json5
@@ -4,9 +4,8 @@
       {
         name: 'default',
         signingConfig: 'default',
-        compileSdkVersion: '4.1.0(11)',
-        compatibleSdkVersion: '4.1.0(11)',
-        runtimeOS: 'HarmonyOS',
+        compatibleSdkVersion: "5.0.0(12)",
+        runtimeOS: 'HarmonyOS'
       },
     ],
     buildModeSet: [
@@ -17,8 +16,7 @@
         name: 'release',
       },
     ],
-    "signingConfigs": [
-    ]
+    "signingConfigs": []
   },
   modules: [
     {
@@ -36,6 +34,6 @@
     {
       name: 'svg',
       srcPath: './svg',
-    },
+    }
   ],
 }

--- a/tester/package.json
+++ b/tester/package.json
@@ -8,6 +8,7 @@
     "pack:pkg": "cd ../react-native-harmony-svg && npm pack && cd ../tester",
     "install:pkg": "npm run pack:pkg && npm i @react-native-oh-tpl/react-native-svg@file:../react-native-harmony-svg/react-native-oh-tpl-react-native-svg-15.0.0-0.5.4.tgz",
     "dev": "npm uninstall react-native-harmony-svg && npm run install:pkg && react-native bundle-harmony --dev --minify=false",
+    "postinstall": "node ./scripts/create-build-profile",
     "android": "react-native run-android"
   },
   "dependencies": {

--- a/tester/scripts/create-build-profile.js
+++ b/tester/scripts/create-build-profile.js
@@ -1,0 +1,39 @@
+const fs = require('fs');
+const JSON5 = require('json5');
+const path = require('path');
+
+const templatePath = path.join(
+  __dirname,
+  '..',
+  'harmony',
+  'build-profile.template.json5',
+);
+const existingProfilePath = path.join(
+  __dirname,
+  '..',
+  'harmony',
+  'build-profile.json5',
+);
+
+if (fs.existsSync(existingProfilePath)) {
+  let existingProfile = JSON5.parse(
+    fs.readFileSync(existingProfilePath, 'utf-8'),
+  );
+  let template = JSON5.parse(fs.readFileSync(templatePath, 'utf-8'));
+  let signingConfigs =
+    existingProfile.app && existingProfile.app.signingConfigs;
+
+  existingProfile = {...template};
+
+  if (signingConfigs) {
+    existingProfile.app.signingConfigs = signingConfigs;
+  }
+
+  fs.writeFileSync(
+    existingProfilePath,
+    JSON5.stringify(existingProfile, null, 2),
+  );
+} else {
+  // File doesn't exist, create a copy from the template
+  fs.copyFileSync(templatePath, existingProfilePath);
+}


### PR DESCRIPTION
<!-- 感谢您提交PR！请按照模板填写，以便审阅者可以轻松理解和评估代码变更的影响。Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary

Implement a JS script to automatically generate build-profile.json5 for the HarmonyOS project upon executing `npm i`.

## Test Plan

Run `npm i` in tester, and it will generate `build-profile.json5` in tester/harmony

## Checklist

NA
