### PR TITLE
optimization: use std::lock_guard<std::mutex> to ensure that access to m_svgNode is synchronized between threads

### DIFF
--- a/tester/harmony/svg/src/main/cpp/SvgHost.h
+++ b/tester/harmony/svg/src/main/cpp/SvgHost.h
@@ -9,15 +9,22 @@ class SvgHost {
  public:
      SvgHost() = default;
      virtual ~SvgHost() = default;
-     void SetSvgNode(const std::shared_ptr<SvgNode> &svgNode) { m_svgNode = svgNode; };
-     const std::shared_ptr<SvgNode> &GetSvgNode() const { return m_svgNode; };
+     void SetSvgNode(const std::shared_ptr<SvgNode> &svgNode) { 
+        std::lock_guard<std::mutex> lock(mtx);
+        m_svgNode = svgNode;
+    };
+     const std::shared_ptr<SvgNode> &GetSvgNode() const { 
+        std::lock_guard<std::mutex> lock(mtx);
+        return m_svgNode;
+    };
 
      void OnChildInsertCommon(const std::shared_ptr<SvgHost> &childSvgHost);
 
      void OnChildRemoveCommon(const std::shared_ptr<SvgHost> &childSvgHost);
 
  private:
-  std::shared_ptr<SvgNode> m_svgNode;
+  std::shared_ptr<SvgNode> m_svgNode{nullptr};
+  mutable std::mutex mtx;
 };
 
 } // namespace svg


### PR DESCRIPTION
<!-- 感谢您提交PR！请按照模板填写，以便审阅者可以轻松理解和评估代码变更的影响。Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary

具体来说，std::n1::shared_ptr_emplace<facebook::jsi::Function, std::n1::allocator<facebook::jsi::Function>>::on_zero_shared() 这个函数会在最后一个 shared_ptr 指向的对象被销毁时调用。它的作用是调用该对象的删除器（通常是析构函数），以清理和释放资源。
对于 shared_ptr<facebook::jsi::Function> 来说，问题可能在于这个 shared_ptr 的生命周期超过了它原本应该关联的 jsi::Runtime 对象的生命周期。这意味着 shared_ptr 仍然存在，但它指向的 jsi::Runtime 对象已经被销毁了。因此，当尝试访问或操作与已经销毁的 jsi::Runtime 相关联的对象时，就会引发错误。简单来说，就是你的 shared_ptr 可能还在使用，但是底层的 jsi::Runtime 已经不存在了，这导致了潜在的问题。

## Test Plan

none

closed #277

