### PR TITLE
fix: 在沙箱路径下，bundle同级目录资源加载失败

### DIFF
--- a/tester/harmony/svg/src/main/cpp/SvgImage.h
+++ b/tester/harmony/svg/src/main/cpp/SvgImage.h
@@ -31,11 +31,16 @@ public:
     
     void setNativeResourceManager(const NativeResourceManager* mgr) { mgr_ = mgr; }
     
+    void setBundlePath(const std::string &path) { bundlePath_ = path; }
+    
+    void getAssetSandbox(const std::string &assetPath, std::string &uri);
+    
     void OnDraw(OH_Drawing_Canvas *canvas) override;
-
+    
 private:
     SvgImageAttribute imageAttribute_;
     const NativeResourceManager* mgr_;
+    std::string bundlePath_;
 };
 
 } // namespace svg

--- a/tester/harmony/svg/src/main/cpp/componentInstances/RNSVGImageComponentInstance.cpp
+++ b/tester/harmony/svg/src/main/cpp/componentInstances/RNSVGImageComponentInstance.cpp
@@ -26,6 +26,26 @@ void RNSVGImageComponentInstance::UpdateElementProps(SharedConcreteProps const &
     svgImage->SetAlign(props->align);
     svgImage->SetMeetOrSlice(props->meetOrSlice);
     svgImage->SetImageSource(props->src);
+    svgImage->setBundlePath(getBundlePath());
+}
+
+std::string RNSVGImageComponentInstance::getBundlePath() {
+    if (!m_deps) {
+        return "";
+    }
+    auto rnInstance = m_deps->rnInstance.lock();
+    if (!rnInstance) {
+        return "";
+    }
+    auto internalInstance = std::dynamic_pointer_cast<RNInstanceInternal>(rnInstance);
+    if (!internalInstance) {
+        return "";
+    }
+    std::string bundlePath = internalInstance->getBundlePath();
+    if (bundlePath.empty()) {
+        return "";
+    }
+    return bundlePath;
 }
 
 } // namespace svg

--- a/tester/harmony/svg/src/main/cpp/componentInstances/RNSVGImageComponentInstance.h
+++ b/tester/harmony/svg/src/main/cpp/componentInstances/RNSVGImageComponentInstance.h
@@ -36,6 +36,8 @@ public:
     RNSVGImageComponentInstance(Context context);
 
     void UpdateElementProps(SharedConcreteProps const &props) override;
+    
+    std::string getBundlePath();
 };
 
 } // namespace svg


### PR DESCRIPTION
# Summary

  修复在沙箱路径下，bundle同级目录资源加载失败

## Test Plan
1. 在index.ets中的jsBundleProvider的FileJSBundleProvider的路径放置生成的bundle文件和资源文件
2. 删除rawfile目录下的资源文件
3. 运行程序

Resolve #278 #265

