### PR TITLE
fix:  cpp crash in textPath due to null pointer dereference

### DIFF
--- a/tester/harmony/svg/src/main/cpp/SvgTSpan.cpp
+++ b/tester/harmony/svg/src/main/cpp/SvgTSpan.cpp
@@ -203,6 +203,8 @@ void SvgTSpan::DrawTextPath(OH_Drawing_Canvas *canvas) {
     for (int i = 0; i < content_.size(); i++) {
         std::string current = content_.substr(i, 1);
 
+        auto *fontCollection = OH_Drawing_CreateFontCollection();
+        auto *typographyHandler = OH_Drawing_CreateTypographyHandler(ts.typographyStyle_.get(), fontCollection);
         OH_Drawing_TypographyHandlerAddText(typographyHandler, current.c_str());
         drawing::Typography typography(typographyHandler);
         OH_Drawing_TypographyLayout(&typography, 1e9);
@@ -247,6 +249,8 @@ void SvgTSpan::DrawTextPath(OH_Drawing_Canvas *canvas) {
         if (alreadyRenderedGraphemeCluster || isWordSeparator) {
             // Skip rendering other grapheme clusters of ligatures (already rendered),
             // But, make sure to increment index positions by making gc.next() calls.
+            OH_Drawing_DestroyFontCollection(fontCollection);
+            OH_Drawing_DestroyTypographyHandler(typographyHandler);
             continue;
         }
         int side = ph.GetSide();
@@ -257,6 +261,8 @@ void SvgTSpan::DrawTextPath(OH_Drawing_Canvas *canvas) {
 
         drawing::Matrix mid;
         if (!ph.GetMatrixOnPath({charWidth, startPoint, y, dy + baselineShift}, mid)) {
+            OH_Drawing_DestroyFontCollection(fontCollection);
+            OH_Drawing_DestroyTypographyHandler(typographyHandler);
             continue;
         }
         mid.PreRotate(r, 0, 0);
@@ -265,6 +271,9 @@ void SvgTSpan::DrawTextPath(OH_Drawing_Canvas *canvas) {
         OH_Drawing_CanvasConcatMatrix(canvas, mid.get());
         OH_Drawing_TypographyPaint(&typography, canvas, 0, 0);
         OH_Drawing_CanvasRestore(canvas);
+        
+        OH_Drawing_DestroyFontCollection(fontCollection);
+        OH_Drawing_DestroyTypographyHandler(typographyHandler);
     }
     OH_Drawing_DestroyFontCollection(fontCollection);
     OH_Drawing_DestroyTypographyHandler(typographyHandler);


### PR DESCRIPTION
<!-- 感谢您提交PR！请按照模板填写，以便审阅者可以轻松理解和评估代码变更的影响。Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary

textPath 测试用例点击crash，是错误使用os接口导致，修改使用方式后得到处理

## Test Plan

Test is available in svgDemoCases components TextPath

closed #281

