### PR TITLE
fix: when setting the x or y property, the Image is not displayed completely

### DIFF
--- a/tester/harmony/svg/src/main/cpp/SvgImage.cpp
+++ b/tester/harmony/svg/src/main/cpp/SvgImage.cpp
@@ -130,7 +130,7 @@ void SvgImage::OnDraw(OH_Drawing_Canvas *canvas) {
 
             // Draw picture by type OH_Drawing_PixelMap
             OH_Drawing_CanvasSave(canvas);
-            drawing::Rect clipRect(x, y, width, height);
+            drawing::Rect clipRect(x, y, x + width, y + height);
             OH_Drawing_CanvasClipRect(canvas, clipRect.get(), OH_Drawing_CanvasClipOp::INTERSECT, true);
             OH_Drawing_CanvasDrawPixelMapRect(canvas, ohPixelMap, srcPixelMap.get(), dstPixelMap.get(),
                                               samplingOptions);


### PR DESCRIPTION
# Summary

修复在设置x或y属性时，Image显示不完整，与IOS表现不一致

## Test Plan

运行demo，查看image的设置x或y属性的示例，图片与IOS显示一致

Resolve #291 