### PR TITLE
refactor: modify share_prt children_ to weak_ptr

### DIFF
--- a/tester/harmony/svg/src/main/cpp/SvgDefs.h
+++ b/tester/harmony/svg/src/main/cpp/SvgDefs.h
@@ -24,14 +24,11 @@ public:
     drawing::Path AsPath() override {
         drawing::Path path;
         DLOG(INFO) << "[SvgDfes:AsPath] : arrived Defs AsPath";
-        for (auto child : children_) {
-            if (!child) {
-                DLOG(INFO) << "[SvgDfes:AsPath] : childnode is a null ptr";
-            } else {
-                DLOG(INFO) << "[SvgDfes:AsPath] : get child path:";
+        for (auto &node : children_) {
+            if (auto child = node.lock()) {
+                auto childPath = child->AsPath();
+                path.Union(childPath);
             }
-            auto childPath = child->AsPath();
-            path.Union(childPath);
         }
         return path;
     }

--- a/tester/harmony/svg/src/main/cpp/SvgGroup.cpp
+++ b/tester/harmony/svg/src/main/cpp/SvgGroup.cpp
@@ -15,7 +15,8 @@ void SvgGroup::OnInitStyle() {
     if (!font_) {
         InitFont(GetScale());
     }
-    for (auto &child : children_) {
+    for (auto &node : children_) {
+        auto child = node.lock();
         if (auto childG = std::dynamic_pointer_cast<FontHolderBase>(child)) {
             childG->InheritFont(font_, child->GetScale());
         }

--- a/tester/harmony/svg/src/main/cpp/SvgNode.cpp
+++ b/tester/harmony/svg/src/main/cpp/SvgNode.cpp
@@ -38,8 +38,10 @@ void SvgNode::InitStyle(const SvgBaseAttribute &attr) {
     OnInitStyle();
     if (passStyle_) {
         for (auto &node : children_) {
-            // pass down style only if child inheritStyle_ is true
-            node->InitStyle((node->inheritStyle_) ? attributes_ : SvgBaseAttribute());
+            if (auto child = node.lock()) {
+                // pass down style only if child inheritStyle_ is true
+                child->InitStyle((child->inheritStyle_) ? attributes_ : SvgBaseAttribute());
+            }
         }
     }
 }
@@ -47,11 +49,13 @@ void SvgNode::InitStyle(const SvgBaseAttribute &attr) {
 void SvgNode::OnDrawTraversed(OH_Drawing_Canvas *canvas) {
     auto smoothEdge = GetSmoothEdge();
     for (auto &node : children_) {
-        if (node && node->drawTraversed_) {
-            if (GreatNotEqual(smoothEdge, 0.0f)) {
-                node->SetSmoothEdge(smoothEdge);
+        if (auto child = node.lock()) {
+            if (child && child->drawTraversed_) {
+                if (GreatNotEqual(smoothEdge, 0.0f)) {
+                    child->SetSmoothEdge(smoothEdge);
+                }
+                child->Draw(canvas);
             }
-            node->Draw(canvas);
         }
     }
 }
@@ -188,9 +192,11 @@ void SvgNode::ContextTraversal() {
     if (!attributes_.id.empty()) {
         context_->Push(attributes_.id, shared_from_this());
     }
-    for (const auto &child : children_) {
-        child->SetContext(context_);
-        child->ContextTraversal();
+    for (const auto &node : children_) {
+        if (auto child = node.lock()) {
+            child->SetContext(context_);
+            child->ContextTraversal();
+        }
     }
 }
 

--- a/tester/harmony/svg/src/main/cpp/SvgNode.h
+++ b/tester/harmony/svg/src/main/cpp/SvgNode.h
@@ -43,8 +43,14 @@ public:
 
     virtual void AppendChild(const std::shared_ptr<SvgNode> &child) { children_.emplace_back(child); }
 
-    virtual void removeChild(const std::shared_ptr<SvgNode> &child) {
-        auto it = std::find(children_.begin(), children_.end(), child);
+    virtual void removeChild(const std::shared_ptr<SvgNode>& child) {
+        // 查找 children_ 中与提供的 shared_ptr 匹配的 weak_ptr
+        auto it = std::find_if(children_.begin(), children_.end(),
+            [&child](const std::weak_ptr<SvgNode>& weakChild) {
+                auto lockedChild = weakChild.lock();
+                return lockedChild == child;
+            });
+
         if (it != children_.end()) {
             children_.erase(it);
         }
@@ -180,7 +186,7 @@ protected:
 
     std::shared_ptr<SvgContext> context_;
 
-    std::vector<std::shared_ptr<SvgNode>> children_;
+    std::vector<std::weak_ptr<SvgNode>> children_;
 
     std::string hrefClipPath_;
     std::string imagePath_;

--- a/tester/harmony/svg/src/main/cpp/SvgQuote.h
+++ b/tester/harmony/svg/src/main/cpp/SvgQuote.h
@@ -12,18 +12,22 @@ public:
 
     drawing::Path getClipPath(drawing::Path path) {
         DLOG(INFO) << "[SvgQuote] getClipPath";
-        for (const auto &child : children_) {
-            auto childPath = child->AsPath();
-            path.AddPath(childPath);
+        for (const auto &node : children_) {
+            if (auto child = node.lock()) {
+                auto childPath = child->AsPath();
+                path.AddPath(childPath);
+            }
         }
         return path;
     }
 
     drawing::Path getClipPath(drawing::Path path, drawing::Path::OpMode op) {
         DLOG(INFO) << "[SvgQuote] getClipPath with op, op = " << op;
-        for (const auto &child : children_) {
-            auto childPath = child->AsPath();
-            path.Op(childPath, op);
+        for (const auto &node : children_) {
+            if (auto child = node.lock()) {
+                auto childPath = child->AsPath();
+                path.Op(childPath, op);
+            }
         }
         return path;
     }

--- a/tester/harmony/svg/src/main/cpp/SvgSvg.cpp
+++ b/tester/harmony/svg/src/main/cpp/SvgSvg.cpp
@@ -21,9 +21,12 @@ SvgSvg::SvgSvg() : SvgGroup() {}
 
 drawing::Path SvgSvg::AsPath() {
     drawing::Path path;
-    for (const auto &child : children_) {
-        auto childPath = child->AsPath();
-        path.Union(childPath);
+    for (const auto &node : children_) {
+        if (auto child = node.lock()) {
+            auto childPath = child->AsPath();
+            path.Union(childPath);
+        }
+
     }
     return path;
 }

--- a/tester/harmony/svg/src/main/cpp/SvgTSpan.cpp
+++ b/tester/harmony/svg/src/main/cpp/SvgTSpan.cpp
@@ -20,7 +20,7 @@ void SvgTSpan::OnDraw(OH_Drawing_Canvas *canvas) {
     }
     if (content_.empty()) {
         for (const auto &child : children_) {
-            if (auto tSpan = std::dynamic_pointer_cast<SvgTSpan>(child); tSpan) {
+            if (auto tSpan = std::dynamic_pointer_cast<SvgTSpan>(child.lock()); tSpan) {
                 tSpan->SetGlyphContext(glyphCtx_);
             }
         }

--- a/tester/harmony/svg/src/main/cpp/SvgText.cpp
+++ b/tester/harmony/svg/src/main/cpp/SvgText.cpp
@@ -14,7 +14,7 @@ void SvgText::GlyphTraversal(OH_Drawing_Canvas *canvas) {
         InitGlyph(canvas, scale_);
     }
     for (auto const &child : children_) {
-        if (auto span = std::dynamic_pointer_cast<TextBase>(child)) {
+        if (auto span = std::dynamic_pointer_cast<TextBase>(child.lock())) {
             span->SetGlyphContext(glyphCtx_);
             if (!span->hasAlignmentBaseline()) {
                 span->setAlignmentBaseline(align_);

--- a/tester/harmony/svg/src/main/cpp/SvgTextPath.cpp
+++ b/tester/harmony/svg/src/main/cpp/SvgTextPath.cpp
@@ -9,7 +9,7 @@ void SvgTextPath::OnDraw(OH_Drawing_Canvas *canvas) {
         InitGlyph(canvas, scale_);
     }
     for (auto const &child : children_) {
-        if (auto tSpan = std::dynamic_pointer_cast<SvgTSpan>(child)) {
+        if (auto tSpan = std::dynamic_pointer_cast<SvgTSpan>(child.lock())) {
             tSpan->SetGlyphContext(glyphCtx_);
             tSpan->SetTextPathRef(std::dynamic_pointer_cast<SvgTextPath>(shared_from_this()));
         }


### PR DESCRIPTION
<!-- 感谢您提交PR！请按照模板填写，以便审阅者可以轻松理解和评估代码变更的影响。Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary

The lifecycle of an SvgNode pointer should be managed by the componentInstance, rather than by other SvgNode instances. Therefore, it is unnecessary to use shared_ptr to manage the children_ of an SvgNode.

## Test Plan

Run all the svgDemoCases.

## Checklist

<!-- 检查项, 请自行排查并打钩, 通过: [X] -->

- [X] 已经在真机设备或模拟器上测试通过
- [X] 已经与 Android 或 iOS 平台做过效果/功能对比
