### PR TITLE
fix: memory leaks caused by SvgViewManager not properly releasing the SvgSvg weak_ptr

### DIFF
--- a/tester/harmony/svg/src/main/cpp/componentInstances/RNSVGSvgViewComponentInstance.cpp
+++ b/tester/harmony/svg/src/main/cpp/componentInstances/RNSVGSvgViewComponentInstance.cpp
@@ -12,6 +12,10 @@ RNSVGSvgViewComponentInstance::RNSVGSvgViewComponentInstance(Context context)
     SvgViewManager::getInstance().setSvgView(CppComponentInstance::getTag(), dynamic_pointer_cast<SvgSvg>(GetSvgNode()));
 }
 
+RNSVGSvgViewComponentInstance::~RNSVGSvgViewComponentInstance() {
+    SvgViewManager::getInstance().onDropView(CppComponentInstance::getTag());
+}
+
 void RNSVGSvgViewComponentInstance::onPropsChanged(SharedConcreteProps const &props) {
     CppComponentInstance::onPropsChanged(props);
     DLOG(INFO) << "[SVG] <SVGViewComponentInstance> props->width: " << m_layoutMetrics.frame.size.width;

--- a/tester/harmony/svg/src/main/cpp/componentInstances/RNSVGSvgViewComponentInstance.h
+++ b/tester/harmony/svg/src/main/cpp/componentInstances/RNSVGSvgViewComponentInstance.h
@@ -16,6 +16,7 @@ private:
 
 public:
     RNSVGSvgViewComponentInstance(Context context);
+    ~RNSVGSvgViewComponentInstance();
 
     // get SvgNode from childComponentInstance and set it to root_
     void onChildInserted(ComponentInstance::Shared const &childComponentInstance, std::size_t index) override {


### PR DESCRIPTION
<!-- 感谢您提交PR！请按照模板填写，以便审阅者可以轻松理解和评估代码变更的影响。Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary

SvgViewManager 未释放 SvgSvg weak_ptr 导致内存泄露

## Test Plan

使用IDE profile工具的Allocation：反复点击 tester App，内存没有增长，退出界面后SvgViewComponentInstncae没有未释放的记录。

closed #289 

## Checklist

<!-- 检查项, 请自行排查并打钩, 通过: [X] -->

- [x] 已经在真机设备或模拟器上测试通过
