### PR TITLE
fix: TSpan props are ineffective when two tspan elements have a parent-child relationship

### DIFF
--- a/tester/harmony/entry/src/main/ets/pages/Index.ets
+++ b/tester/harmony/entry/src/main/ets/pages/Index.ets
@@ -14,31 +14,17 @@ import font from '@ohos.font';
 import { createRNPackages } from '../RNPackagesFactory';
 
 const arkTsComponentNames: Array<string> = ["SampleView", "GeneratedSampleView", "PropsDisplayer"];
+
 @Builder
 export function buildCustomRNComponent(ctx: ComponentBuilderContext) {
   // There seems to be a problem with the placement of ArkTS components in mixed mode. Nested Stack temporarily avoided.
-  Stack(){
+  Stack() {
   }
-  .position({x:0, y: 0})
+  .position({ x: 0, y: 0 })
 
 }
 
 const wrappedCustomRNComponentBuilder = wrapBuilder(buildCustomRNComponent)
-
-/**
- * If you want to use custom fonts, you need to register them here.
- * We should support react-native-asset to handle registering fonts automatically.
- */
-const fonts: font.FontOptions[] = [
-  {
-    familyName: 'Pacifico-Regular',
-    familySrc: '/assets/fonts/Pacifico-Regular.ttf'
-  },
-  {
-    familyName: 'StintUltraCondensed-Regular',
-    familySrc: '/assets/fonts/StintUltraCondensed-Regular.ttf'
-  }
-]
 
 @Entry
 @Component
@@ -47,14 +33,9 @@ struct Index {
   @State shouldShow: boolean = false
   private logger!: RNOHLogger
 
-
   aboutToAppear() {
     this.logger = this.rnohCoreContext!.logger.clone("Index")
     const stopTracing = this.logger.clone("aboutToAppear").startTracing()
-    for (const customFont of fonts) {
-      font.registerFont(customFont)
-    }
-
     this.shouldShow = true
     stopTracing()
   }
@@ -80,6 +61,9 @@ struct Index {
             enableBackgroundExecutor: false,
             enableCAPIArchitecture: true,
             arkTsComponentNames: arkTsComponentNames,
+            fontResourceByFontFamily: {
+              "PingFangSC-Regular": $rawfile('assets/fonts/PingFang-SC-Regular.ttf'),
+            },
           },
           initialProps: { "foo": "bar" } as Record<string, string>,
           appKey: "svg",

--- a/tester/harmony/svg/src/main/cpp/SvgTSpan.cpp
+++ b/tester/harmony/svg/src/main/cpp/SvgTSpan.cpp
@@ -22,11 +22,11 @@ void SvgTSpan::OnDraw(OH_Drawing_Canvas *canvas) {
         for (const auto &child : children_) {
             if (auto tSpan = std::dynamic_pointer_cast<SvgTSpan>(child); tSpan) {
                 tSpan->SetGlyphContext(glyphCtx_);
+                UpdateChildTextProps(tSpan);
             }
         }
         return;
     }
-
 
     glyphCtx_->pushContext(false, shared_from_this(), x_, y_, dx_, dy_, rotate_);
     if (!textPath_) {
@@ -61,7 +61,9 @@ void SvgTSpan::DrawText(OH_Drawing_Canvas *canvas) {
 
     OH_Drawing_Font_Metrics fm;
     OH_Drawing_TextStyleGetFontMetrics(typographyForMetrics, textStyle.textStyle_.get(), &fm);
-    double dx = glyphCtx_->nextX(actualWidth) - actualWidth + glyphCtx_->nextDeltaX() +
+    // Ceil the actual width to avoid small floating-point errors and ensure proper alignment
+    // when calculating the position of the next glyph and adjusting for the text anchor.
+    double dx = glyphCtx_->nextX(actualWidth) - std::ceil(actualWidth) + glyphCtx_->nextDeltaX() +
                 getTextAnchorOffset(font_->textAnchor, actualWidth);
     // the position of typography is on the left-top
     double dy = glyphCtx_->nextY() + glyphCtx_->nextDeltaY() +
@@ -271,7 +273,7 @@ void SvgTSpan::DrawTextPath(OH_Drawing_Canvas *canvas) {
         OH_Drawing_CanvasConcatMatrix(canvas, mid.get());
         OH_Drawing_TypographyPaint(&typography, canvas, 0, 0);
         OH_Drawing_CanvasRestore(canvas);
-        
+
         OH_Drawing_DestroyFontCollection(fontCollection);
         OH_Drawing_DestroyTypographyHandler(typographyHandler);
     }

--- a/tester/harmony/svg/src/main/cpp/SvgTSpan.h
+++ b/tester/harmony/svg/src/main/cpp/SvgTSpan.h
@@ -26,28 +26,64 @@ public:
     void OnDraw(OH_Drawing_Canvas *canvas) override;
 
     void SetTextPathRef(std::shared_ptr<SvgTextPath> textPath) { textPath_ = textPath; }
-    
+
     double getTextAnchorOffset(TextAnchor textAnchor, const double &textMeasure);
-    
+
     std::string content_;
-    
+
     Rect AsBounds() override;
 
+    /**
+     * @brief TSpan also supports the scenario with child nodes. Updates the font properties of the child node,
+     *        inheriting from the parent node if the properties are empty.
+     */
+    void OnInitStyle() override {
+        if (!font_) {
+            InitFont(GetScale());
+        }
+        for (auto &child : children_) {
+            if (auto childG = std::dynamic_pointer_cast<FontHolderBase>(child)) {
+                childG->InheritFont(font_, child->GetScale());
+            }
+        }
+    };
+
 private:
-    void DrawTextPath(OH_Drawing_Canvas* canvas);
-    void DrawText(OH_Drawing_Canvas* canvas);
+    /**
+     * @brief TSpan also supports the scenario with child nodes. Updates the text properties of the child node,
+     *        inheriting from the parent node if the properties are empty.
+     * @param child Represents the child node object.
+     */
+    void UpdateChildTextProps(std::shared_ptr<SvgTSpan> child) {
+        UpdateIfEmpty(child->y_, y_);
+        UpdateIfEmpty(child->x_, x_);
+        UpdateIfEmpty(child->dy_, dy_);
+        UpdateIfEmpty(child->dx_, dx_);
+        UpdateIfEmpty(child->rotate_, rotate_);
+    }
+
+    void UpdateIfEmpty(std::vector<Dimension> &childProp, const std::vector<Dimension> &parentProp) {
+        if (childProp.empty() && !parentProp.empty()) {
+            childProp = parentProp;
+        }
+    }
+
+    void DrawTextPath(OH_Drawing_Canvas *canvas);
+
+    void DrawText(OH_Drawing_Canvas *canvas);
 
     drawing::TypographyStyle PrepareTypoStyle();
 
     /**
      * @return true if spacing needs to be adjusted.
      */
-    bool AdjustSpacing(OH_Drawing_Canvas *canvas, double textMeasure, double& scaleSpacingAndGlyphs);
+    bool AdjustSpacing(OH_Drawing_Canvas *canvas, double textMeasure, double &scaleSpacingAndGlyphs);
 
-    double CalcBaselineShift(OH_Drawing_TypographyCreate* handler, OH_Drawing_TextStyle* style, const OH_Drawing_Font_Metrics& fm);
+    double CalcBaselineShift(OH_Drawing_TypographyCreate *handler, OH_Drawing_TextStyle *style,
+                             const OH_Drawing_Font_Metrics &fm);
 
     std::shared_ptr<SvgTextPath> textPath_;
-    
+
     double boundsWidth_ = 0;
     double boundsHeight_ = 0;
     double boundsX_ = 0;

--- a/tester/svgDemoCases/components/IssueFix.tsx
+++ b/tester/svgDemoCases/components/IssueFix.tsx
@@ -27,6 +27,7 @@ import Issue236 from './issueTests/Issue236';
 import Issue244 from './issueTests/Issue244';
 import Issue267 from './issueTests/Issue267';
 import Issue280 from './issueTests/Issue280';
+import Issue308 from './issueTests/Issue308';
 
 class SvgLayoutExample extends Component {
   static title = 'SVG with flex layout';
@@ -399,6 +400,9 @@ export default function () {
         </TestCase>
         <TestCase itShould="Issue #280: The svg image is not displayed when mask and use are used at the same time.">
           <Issue280 />
+        </TestCase>
+        <TestCase itShould="Issue #308: The TSpan should be displayed with proper alignment.">
+          <Issue308 />
         </TestCase>
       </ScrollView>
     </Tester>

--- a/tester/svgDemoCases/components/issueTests/Issue308.tsx
+++ b/tester/svgDemoCases/components/issueTests/Issue308.tsx
@@ -1,0 +1,39 @@
+import React, {Component} from 'react';
+import {View, StyleSheet} from 'react-native';
+import {SvgXml} from 'react-native-svg';
+
+const textIcon = `<?xml version="1.0" encoding="UTF-8"?>
+<svg width="21px" height="21px" viewBox="0 0 21 21" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <title>cfa-acct-overview-open-step-e-1</title>
+    <g id="1" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+        <g id="2" transform="translate(-457.000000, -1989.000000)" fill="#1E53A4" fill-rule="nonzero">
+            <g id="3" transform="translate(457.510121, 1989.846731)">
+                <rect id="4" opacity="0.15" x="0" y="0" width="20" height="20" rx="10"></rect>
+                <g id="5" transform="translate(7.552000, 1.166667)" font-family="PingFangSC-Regular, PingFang SC" font-size="12" font-weight="normal">
+                    <text>
+                        <tspan x="0" y="13">1</tspan>
+                    </text>
+                </g>
+            </g>
+        </g>
+    </g>
+</svg>`;
+
+export default class Issue308 extends Component {
+  render() {
+    return (
+      <View style={styles.container}>
+        <SvgXml xml={textIcon} width={100} height={100} />
+      </View>
+    );
+  }
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: 'white',
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+});


### PR DESCRIPTION
<!-- 感谢您提交PR！请按照模板填写，以便审阅者可以轻松理解和评估代码变更的影响。Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary
solved #308 
在导入xml格式的svg时，TSPan会创建两个节点，互为父子关系（demo见issue）。父节点会接收到x/y等属性，content会在子节点接收。在此前的版本里没有考虑这种情况，没有在TSPan实现属性继承的功能。另外如果分段写TSPan也能复现，demo如下：
```js
<Svg height="200" width="300" viewBox="0 0 200 100">
    <Text x="10" y="20" fontSize="16" fontFamily="Verdana" fill="black" >
        <TSpan fill="blue" y="30" fontWeight="lighter">
            {"tt"}
            ss
            {"tt"}
        </TSpan>
    </Text>
</Svg>
```

## Test Plan

SvgTestCase issueFix section: issue308

## Checklist

<!-- 检查项, 请自行排查并打钩, 通过: [X] -->

- [X] 已经在真机设备或模拟器上测试通过
- [X] 已经与 Android 或 iOS 平台做过效果/功能对比
- [X] 已经添加了对应 API 的测试用例（如需要）
