### PR TITLE
fix: Path did not update when the point scale factor changed

### DIFF
--- a/tester/harmony/svg/src/main/cpp/componentInstances/RNSVGPathComponentInstance.cpp
+++ b/tester/harmony/svg/src/main/cpp/componentInstances/RNSVGPathComponentInstance.cpp
@@ -12,9 +12,13 @@ void RNSVGPathComponentInstance::UpdateElementProps() {
     DLOG(INFO) << "[RNSVGPathCI] d: " << m_props->d;
     DLOG(INFO) << "[RNSVGPathCI] pointScaleFactor: " << m_layoutMetrics.pointScaleFactor;
     m_svgPath->UpdateCommonProps(m_props);
-    if (m_cacheD.empty() || m_cacheD != m_props->d) {
-        m_svgPath->setD(m_props->d);
-        m_cacheD = m_props->d;
+    // Check if path data or scale factor has changed
+    if (m_cacheD != m_props->d || m_cacheScale != m_layoutMetrics.pointScaleFactor) {
+        m_svgPath->setD(m_props->d); // Update path data
+        m_cacheD = m_props->d;       // Cache the new path data
+        m_cacheScale = m_layoutMetrics.pointScaleFactor; // Cache the new scale factor
+    } else {
+        LOG(INFO) << "[RNSVGPathCI] No changes detected. Skipping update.";
     }
 }
 

--- a/tester/harmony/svg/src/main/cpp/componentInstances/RNSVGPathComponentInstance.h
+++ b/tester/harmony/svg/src/main/cpp/componentInstances/RNSVGPathComponentInstance.h
@@ -16,6 +16,7 @@ protected:
 private:
     std::shared_ptr<SvgPath> m_svgPath = std::make_shared<SvgPath>();
     std::string m_cacheD;
+    Float m_cacheScale;
 };
 
 } // namespace svg


### PR DESCRIPTION
<!-- 感谢您提交PR！请按照模板填写，以便审阅者可以轻松理解和评估代码变更的影响。Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary
Fix #316 

path d的更新目前只会判断d变化与否，忽略了屏幕像素密度的变化，这笔修复新增了像素密度变化的判断。

## Test Plan

Run Tester App

## Checklist

<!-- 检查项, 请自行排查并打钩, 通过: [X] -->

- [X] 已经在真机设备或模拟器上测试通过
- [X] 已经与 Android 或 iOS 平台做过效果/功能对比