### PR TITLE
fix: the x/y of the Group do not affect the clip-path

### DIFF
--- a/tester/harmony/svg/src/main/cpp/SvgNode.cpp
+++ b/tester/harmony/svg/src/main/cpp/SvgNode.cpp
@@ -177,11 +177,11 @@ void SvgNode::Draw(OH_Drawing_Canvas *canvas) {
     // mask and filter create extra layers, need to record initial layer count
     const auto count = OH_Drawing_CanvasGetSaveCount(canvas);
     OH_Drawing_CanvasSave(canvas);
-    if (!hrefClipPath_.empty()) {
-        OnClipPath(canvas);
-    }
     if (!attributes_.transform.empty()) {
         OnTransform(canvas);
+    }
+    if (!hrefClipPath_.empty()) {
+        OnClipPath(canvas);
     }
     if (!attributes_.maskId.empty()) {
         OnMask(canvas);

--- a/tester/harmony/svg/src/main/cpp/SvgPath.cpp
+++ b/tester/harmony/svg/src/main/cpp/SvgPath.cpp
@@ -20,8 +20,9 @@ void SvgPath::setD(const std::string &d) {
         path_ = std::move(parser.parse(d.c_str()));
     } catch (const std::runtime_error &e) {
         LOG(ERROR) << "[svgPath] Svg path d invalid, error message: " << e.what();
+        return;
     }
-    elements_ = parser.elements;
+    elements_ = std::move(parser.elements);
     for (PathElement &elem : elements_) {
         for (Point &point : elem.points) {
             point.x *= scale_;

--- a/tester/svgDemoCases/components/IssueFix.tsx
+++ b/tester/svgDemoCases/components/IssueFix.tsx
@@ -28,6 +28,7 @@ import Issue244 from './issueTests/Issue244';
 import Issue267 from './issueTests/Issue267';
 import Issue280 from './issueTests/Issue280';
 import Issue308 from './issueTests/Issue308';
+import Issue324 from './issueTests/Issue324';
 
 class SvgLayoutExample extends Component {
   static title = 'SVG with flex layout';
@@ -403,6 +404,9 @@ export default function () {
         </TestCase>
         <TestCase itShould="Issue #308: The TSpan should be displayed with proper alignment.">
           <Issue308 />
+        </TestCase>
+        <TestCase itShould="Issue #324: The square should be displayed with red, blue, green and yellow.">
+          <Issue324 />
         </TestCase>
       </ScrollView>
     </Tester>

--- a/tester/svgDemoCases/components/issueTests/Issue324.tsx
+++ b/tester/svgDemoCases/components/issueTests/Issue324.tsx
@@ -1,0 +1,27 @@
+import React from 'react';
+import {View} from 'react-native';
+import Svg, {Rect, G, ClipPath, Defs} from 'react-native-svg';
+
+const Issue324 = () => {
+  return (
+    <View>
+      <Svg width="300" height="150" viewBox="0 0 100 150">
+        <Defs>
+          <ClipPath id="clip-rect">
+            <Rect x="10" y="10" width="100" height="100" />
+          </ClipPath>
+        </Defs>
+
+        {/* 应用ClipPath到Group元素，同时加上位移 */}
+        <G x="10" y="10" clipPath="url(#clip-rect)">
+          <Rect x="0" y="0" width="100" height="100" fill="red"/>
+          <Rect x="100" y="0" width="100" height="100" fill="green" />
+          <Rect x="0" y="100" width="100" height="100" fill="blue" />
+          <Rect x="100" y="100" width="100" height="100" fill="yellow" />
+        </G>
+      </Svg>
+    </View>
+  );
+};
+
+export default Issue324;


### PR DESCRIPTION
<!-- 感谢您提交PR！请按照模板填写，以便审阅者可以轻松理解和评估代码变更的影响。Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary

fix #324 

当Group使用clip-path属性时，其x和y属性转换成的transform对clip-path并不生效。原因是OnClipPath先于OnTransform，需要替换顺序，让transform先执行，再clip path。

## Test Plan

run tester app, issueFix section -> issue 324.

## Checklist

<!-- 检查项, 请自行排查并打钩, 通过: [X] -->

- [X] 已经在真机设备或模拟器上测试通过
- [X] 已经与 Android 或 iOS 平台做过效果/功能对比
- [X] 已经添加了对应 API 的测试用例（如需要）
