### PR TITLE
modify svgimage crash

### DIFF
--- a/tester/harmony/svg/src/main/cpp/componentInstances/RNSVGImageComponentInstance.cpp
+++ b/tester/harmony/svg/src/main/cpp/componentInstances/RNSVGImageComponentInstance.cpp
@@ -74,7 +74,10 @@ std::string RNSVGImageComponentInstance::FindLocalCacheByUri(std::string const &
     }
 
     // 查找缓存目录
-    auto cacheDir = arkTsTurboModule->getImageSourceResolver()->resolveImageSources(*this, uri);
+    auto basePtr = shared_from_this();
+    auto thisPtr = std::static_pointer_cast<RNSVGImageComponentInstance>(basePtr);
+    auto cacheDir = arkTsTurboModule->getImageSourceResolver()->resolveImageSources(thisPtr, uri);
+
     if (!cacheDir.empty()) {
         return cacheDir; // 如果找到缓存文件，返回缓存路径
     }

--- a/tester/harmony/svg/src/main/cpp/downloadUtils/ImageSourceResolver.cpp
+++ b/tester/harmony/svg/src/main/cpp/downloadUtils/ImageSourceResolver.cpp
@@ -61,7 +61,7 @@ void ImageSourceResolver::removeListenerForURI(const std::string &uri, std::shar
     auto listenerPos = std::find_if(listeners.begin(), listeners.end(), [&](const std::weak_ptr<ImageSourceUpdateListener> &wk)
     {
         auto sp = wk.lock();
-        return sp && sp.get() == listeners.get();
+        return sp && sp.get() == listener.get();
 
     });
     if (listenerPos != listeners.end()) {
@@ -95,9 +95,9 @@ void ImageSourceResolver::imageDownloadComplete(std::string uri, std::string fil
     auto &listeners = it->second;
     for (auto listener : listeners) {
 
-        if (auto weaklistener == listener.lock())
+        if (auto weaklistener = listener.lock())
         {
-            listener->onImageSourceCacheUpdate(fileUri);
+            weaklistener->onImageSourceCacheUpdate(fileUri);
             removeListenerForURI(uri, weaklistener);
         }
 
@@ -117,8 +117,8 @@ void ImageSourceResolver::imageDownloadFail(std::string uri) {
     auto &listeners = it->second;
     for (auto listener : listeners) {
 
-        auto weaklistener == listener.lock();
-        listener->onImageSourceCacheDownloadFileFail();
+        auto weaklistener = listener.lock();
+        weaklistener->onImageSourceCacheDownloadFileFail();
         removeListenerForURI(uri, weaklistener);
     }
 }

--- a/tester/harmony/svg/src/main/cpp/downloadUtils/ImageSourceResolver.cpp
+++ b/tester/harmony/svg/src/main/cpp/downloadUtils/ImageSourceResolver.cpp
@@ -10,11 +10,11 @@
 namespace rnoh {
 namespace svg {
 
-std::string ImageSourceResolver::resolveImageSources(ImageSourceUpdateListener &listener, std::string uri) {
+std::string ImageSourceResolver::resolveImageSources(std::shared_ptr<ImageSourceUpdateListener> listener, std::string uri) {
     // 判断是否还在下载中
     if (m_pendingSet.find(uri) != m_pendingSet.end()) {
-        removeListener(&listener);
-        addListenerForURI(uri, &listener);
+        removeListener(listener);
+        addListenerForURI(uri, listener);
         return "";
     }
     // 生成图像的哈希缓存文件名
@@ -25,31 +25,45 @@ std::string ImageSourceResolver::resolveImageSources(ImageSourceUpdateListener &
         auto cacheUri = "file://" + fileCacheDir_ + hashedFileName;
         return cacheUri;
     }
-    removeListener(&listener);
-    addListenerForURI(uri, &listener);
+    removeListener(listener);
+    addListenerForURI(uri, listener);
     return "";
 }
 
-void ImageSourceResolver::addListenerForURI(const std::string &uri, ImageSourceUpdateListener *listener) {
+void ImageSourceResolver::addListenerForURI(const std::string &uri, std::shared_ptr<ImageSourceUpdateListener> listener) {
     listener->observedUri = uri;
     auto it = m_uriListenersMap.find(uri);
     if (it == m_uriListenersMap.end()) {
-        m_uriListenersMap.emplace(uri, std::initializer_list<ImageSourceUpdateListener *>{listener});
+        m_uriListenersMap.emplace(uri, std::vector<std::weak_ptr<ImageSourceUpdateListener>>{listener});
         return;
     }
-    if (std::find(it->second.begin(), it->second.end(), listener) != it->second.end()) {
+
+    auto alreadyThere = std::find_if(it->second.begin(), it->second.end(),[&]  
+    (const std::weak_ptr<ImageSourceUpdateListener> &wk )
+    {   
+        auto sp = wk.lock();
+        return sp && sp.get() == listener.get();
+
+    });
+    if (alreadyThere != it->second.end())
+    {
         return;
     }
     it->second.push_back(listener);
 }
 
-void ImageSourceResolver::removeListenerForURI(const std::string &uri, ImageSourceUpdateListener *listener) {
+void ImageSourceResolver::removeListenerForURI(const std::string &uri, std::shared_ptr<ImageSourceUpdateListener> listener) {
     auto it = m_uriListenersMap.find(uri);
     if (it == m_uriListenersMap.end()) {
         return;
     }
     auto &listeners = it->second;
-    auto listenerPos = std::find(listeners.begin(), listeners.end(), listener);
+    auto listenerPos = std::find_if(listeners.begin(), listeners.end(), [&](const std::weak_ptr<ImageSourceUpdateListener> &wk)
+    {
+        auto sp = wk.lock();
+        return sp && sp.get() == listeners.get();
+
+    });
     if (listenerPos != listeners.end()) {
         listeners.erase(listenerPos);
         if (listeners.empty()) {
@@ -58,7 +72,7 @@ void ImageSourceResolver::removeListenerForURI(const std::string &uri, ImageSour
     }
 }
 
-void ImageSourceResolver::removeListener(ImageSourceUpdateListener *listener) {
+void ImageSourceResolver::removeListener(std::shared_ptr<ImageSourceUpdateListener> listener) {
     if (!listener->observedUri.empty()) {
         removeListenerForURI(listener->observedUri, listener);
     }
@@ -80,8 +94,13 @@ void ImageSourceResolver::imageDownloadComplete(std::string uri, std::string fil
 
     auto &listeners = it->second;
     for (auto listener : listeners) {
-        listener->onImageSourceCacheUpdate(fileUri);
-        removeListenerForURI(uri, listener);
+
+        if (auto weaklistener == listener.lock())
+        {
+            listener->onImageSourceCacheUpdate(fileUri);
+            removeListenerForURI(uri, weaklistener);
+        }
+
     }
 }
 
@@ -97,10 +116,13 @@ void ImageSourceResolver::imageDownloadFail(std::string uri) {
     }
     auto &listeners = it->second;
     for (auto listener : listeners) {
+
+        auto weaklistener == listener.lock();
         listener->onImageSourceCacheDownloadFileFail();
-        removeListenerForURI(uri, listener);
+        removeListenerForURI(uri, weaklistener);
     }
 }
+
 
 } // namespace svg
 } // namespace rnoh

--- a/tester/harmony/svg/src/main/cpp/downloadUtils/ImageSourceResolver.cpp
+++ b/tester/harmony/svg/src/main/cpp/downloadUtils/ImageSourceResolver.cpp
@@ -38,11 +38,11 @@ void ImageSourceResolver::addListenerForURI(const std::string &uri, std::shared_
         return;
     }
 
-    auto alreadyThere = std::find_if(it->second.begin(), it->second.end(),[&]  
+    auto alreadyThere = std::find_if(it->second.begin(), it->second.end(),[&listener]  
     (const std::weak_ptr<ImageSourceUpdateListener> &wk )
     {   
         auto sp = wk.lock();
-        return sp && sp.get() == listener.get();
+        return sp == listener;
 
     });
     if (alreadyThere != it->second.end())
@@ -58,10 +58,10 @@ void ImageSourceResolver::removeListenerForURI(const std::string &uri, std::shar
         return;
     }
     auto &listeners = it->second;
-    auto listenerPos = std::find_if(listeners.begin(), listeners.end(), [&](const std::weak_ptr<ImageSourceUpdateListener> &wk)
+    auto listenerPos = std::find_if(listeners.begin(), listeners.end(), [&listener](const std::weak_ptr<ImageSourceUpdateListener> &wk)
     {
         auto sp = wk.lock();
-        return sp && sp.get() == listener.get();
+        return sp == listener;
 
     });
     if (listenerPos != listeners.end()) {

--- a/tester/harmony/svg/src/main/cpp/downloadUtils/ImageSourceResolver.h
+++ b/tester/harmony/svg/src/main/cpp/downloadUtils/ImageSourceResolver.h
@@ -46,9 +46,6 @@ public:
 
         // 注销监听器
         ~ImageSourceUpdateListener() {
-            if (!m_imageSourceResolver) {
-                m_imageSourceResolver->removeListener(this);
-            }
         }
 
         // 监听图像缓存更新
@@ -71,7 +68,7 @@ public:
     void removeListenerForURI(const std::string &uri, std::shared_ptr<ImageSourceUpdateListener> listener);
 
     // 从解析器中移除监听器
-    void removeListener(std::shared_ptr<ImageSourceUpdateListener> listener);
+    void removeListener(ImageSourceUpdateListener *listener);
 
     // 下载完成后更新图像缓存
     void imageDownloadComplete(std::string uri, std::string fileUri);

--- a/tester/harmony/svg/src/main/cpp/downloadUtils/ImageSourceResolver.h
+++ b/tester/harmony/svg/src/main/cpp/downloadUtils/ImageSourceResolver.h
@@ -62,16 +62,16 @@ public:
     };
 
     // 解析图像源的缓存路径
-    std::string resolveImageSources(ImageSourceUpdateListener &listener, std::string uri);
+    std::string resolveImageSources(std::shared_ptr<ImageSourceUpdateListener> listener, std::string uri);
 
     // 为URI添加监听器
-    void addListenerForURI(const std::string &uri, ImageSourceUpdateListener *listener);
+    void addListenerForURI(const std::string &uri, std::shared_ptr<ImageSourceUpdateListener> listener);
 
     // 从URI移除监听器
-    void removeListenerForURI(const std::string &uri, ImageSourceUpdateListener *listener);
+    void removeListenerForURI(const std::string &uri, std::shared_ptr<ImageSourceUpdateListener> listener);
 
     // 从解析器中移除监听器
-    void removeListener(ImageSourceUpdateListener *listener);
+    void removeListener(std::shared_ptr<ImageSourceUpdateListener> listener);
 
     // 下载完成后更新图像缓存
     void imageDownloadComplete(std::string uri, std::string fileUri);
@@ -87,7 +87,7 @@ public:
 
 private:
     // 存储URI与对应的监听器（支持多个监听器）
-    std::unordered_map<std::string, std::vector<ImageSourceUpdateListener *>> m_uriListenersMap;
+    std::unordered_map<std::string, std::vector<std::weak_ptr<ImageSourceUpdateListener>>> m_uriListenersMap;
 
     // 存储正在下载的图像URI集合
     std::unordered_set<std::string> m_pendingSet;

--- a/tester/harmony/svg/src/main/cpp/downloadUtils/ImageSourceResolver.h
+++ b/tester/harmony/svg/src/main/cpp/downloadUtils/ImageSourceResolver.h
@@ -45,8 +45,7 @@ public:
             : m_imageSourceResolver(ImageSourceResolver) {}
 
         // 注销监听器
-        ~ImageSourceUpdateListener() {
-        }
+        ~ImageSourceUpdateListener() = default;
 
         // 监听图像缓存更新
         virtual void onImageSourceCacheUpdate(std::string imageUri) = 0;


### PR DESCRIPTION
<!-- 感谢您提交PR！请按照模板填写，以便审阅者可以轻松理解和评估代码变更的影响。 -->

# Summary

请解释此次更改的 **动机**，以下是一些帮助您的要点：

- 这个 PR 解决了哪些 issues？请标记这些 issues，以便合并 PR 后这些 issues 将会被自动关闭。
- close #328 
- 这个功能是什么？（如果适用）
- 修复svg image下载崩溃的问题
- 您是如何实现解决方案的？
- ImageSourceResolver这个类里面的普通指针换成weak_ptr和shared_ptr来管理，避免指针悬空的问题。
- 这个更改影响了库的哪些部分？
- 对库的功能和业务逻辑无影响
## Test Plan
展示代码的稳定性。例如：用来复现场景的命令输入和结果输出、测试用例的路径地址，或者附上截图和视频。
## Checklist

<!-- 检查项, 请自行排查并打钩, 通过: [X] -->

- [x] 已经在真机设备或模拟器上测试通过
- [x] 已经与 Android 或 iOS 平台做过效果/功能对比
- [ ] 已经添加了对应 API 的测试用例（如需要）
- [ ] 已经更新了文档（如需要）
- [x] 更新了 JS/TS 代码 (如有)