### PR TITLE
fix:修复适配react-native-svg在低于sdk 15版本上编译运行

### DIFF
--- a/tester/harmony/svg/src/main/cpp/SvgForeignObjectNode.cpp
+++ b/tester/harmony/svg/src/main/cpp/SvgForeignObjectNode.cpp
@@ -6,6 +6,9 @@
 
 #include "SvgForeignObjectNode.h"
 #include "RNOH/arkui/NativeNodeApi.h"
+#include <deviceinfo.h>
+#include <info/application_target_sdk_version.h>
+
 namespace rnoh {
 namespace svg {
 SvgForeignObjectNode::SvgForeignObjectNode()
@@ -45,6 +48,12 @@ void SvgForeignObjectNode::onNodeEvent(ArkUI_NodeEventType eventType, EventArgs 
 }
 
 OH_PixelmapNative *SvgForeignObjectNode::GetNodePixelMap() {
+    DLOG(INFO) << "[svgForeignNode] OH_CURRENT_API_VERSION:" << OH_CURRENT_API_VERSION
+                << ";ROM SDK:" << OH_GetSdkApiVersion();
+#if OH_CURRENT_API_VERSION >= 15
+    if (OH_GetSdkApiVersion() < 15) {
+        return nullptr;
+    }
     OH_PixelmapNative *pixelMap;
     ArkUI_SnapshotOptions *options = OH_ArkUI_CreateSnapshotOptions();
     OH_ArkUI_SnapshotOptions_SetScale(options, 1);
@@ -52,6 +61,7 @@ OH_PixelmapNative *SvgForeignObjectNode::GetNodePixelMap() {
     if (code == ARKUI_ERROR_CODE_NO_ERROR) {
         return pixelMap;
     }
+ #endif
     return nullptr;
 }
 


### PR DESCRIPTION
# Summary

- fix:修复适配react-native-svg在低于sdk 15版本上编译运行
- Close: #345 

## Checklist

<!-- 检查项, 请自行排查并打钩, 通过: [X] -->

- [X] 已经在真机设备或模拟器上测试通过
- [X] 已经与 Android 或 iOS 平台做过效果/功能对比
- [ ] 已经添加了对应 API 的测试用例
- [ ] 已经更新了文档
- [ ] 更新了 JS/TS 代码