### PR TITLE
fix:修復js侧用view设置背景色包裹的子元素，导致svg中显示不出子元素

### DIFF
--- a/tester/harmony/svg/src/main/cpp/componentInstances/RNSVGSvgViewComponentInstance.cpp
+++ b/tester/harmony/svg/src/main/cpp/componentInstances/RNSVGSvgViewComponentInstance.cpp
@@ -20,6 +20,7 @@ RNSVGSvgViewComponentInstance::RNSVGSvgViewComponentInstance(Context context)
 
 RNSVGSvgViewComponentInstance::~RNSVGSvgViewComponentInstance() {
     SvgViewManager::getInstance().onDropView(CppComponentInstance::getTag());
+    noSvgComponentIndex = 0;	
 }
 
 void RNSVGSvgViewComponentInstance::onFinalizeUpdates() {
@@ -64,7 +65,8 @@ void RNSVGSvgViewComponentInstance::onChildInserted(ComponentInstance::Shared co
         for (ComponentInstance::Shared c : childInstance) {
             if (c->getComponentName().find("SVG") == std::string::npos) {
                 NativeNodeApi::getInstance()->insertChildAt(m_svgArkUINode.getArkUINodeHandle(),
-                                                            c->getLocalRootArkUINode().getArkUINodeHandle(), index);
+                                                            c->getLocalRootArkUINode().getArkUINodeHandle(), noSvgComponentIndex);
+                noSvgComponentIndex++;															
             }
             auto groupChildInstance = c->getChildren();
             for (ComponentInstance::Shared c1 : groupChildInstance) {

--- a/tester/harmony/svg/src/main/cpp/componentInstances/RNSVGSvgViewComponentInstance.h
+++ b/tester/harmony/svg/src/main/cpp/componentInstances/RNSVGSvgViewComponentInstance.h
@@ -49,6 +49,7 @@ public:
 private:
     SvgArkUINode m_svgArkUINode;
     std::shared_ptr<SvgSvg> m_svgSvg = std::make_shared<SvgSvg>();
+    int noSvgComponentIndex {0}; // 非svg添加的index(适配js侧view包裹会拆解子元素成平级)
 };
 
 } // namespace svg


### PR DESCRIPTION
# Summary


- Close: #347 
- fix:修復js侧用view设置背景色包裹的子元素，导致svg中显示不出子元素

## Checklist

<!-- 检查项, 请自行排查并打钩, 通过: [X] -->

- [X] 已经在真机设备或模拟器上测试通过
- [ ] 已经与 Android 或 iOS 平台做过效果/功能对比
- [ ] 已经添加了对应 API 的测试用例
- [ ] 已经更新了文档
- [ ] 更新了 JS/TS 代码
