### PR TITLE
fix:修复foreignobject多次生成快照，导致的性能卡顿问题

### DIFF
--- a/tester/harmony/svg/src/main/cpp/SvgForeignObjectNode.cpp
+++ b/tester/harmony/svg/src/main/cpp/SvgForeignObjectNode.cpp
@@ -22,6 +22,7 @@ SvgForeignObjectNode::~SvgForeignObjectNode() {
     if (m_NodeDelegate) {
         m_NodeDelegate = nullptr;
     }
+    _isGeneratedPixelMap = false;	
 }
 void SvgForeignObjectNode::insertChild(ArkUINode &child, std::size_t index) { mStackNode.insertChild(child, index); }
 
@@ -36,12 +37,13 @@ void SvgForeignObjectNode::SetSnapPosition(float x, float y) {
 
 void SvgForeignObjectNode::onNodeEvent(ArkUI_NodeEventType eventType, EventArgs &eventArgs) {
     if (eventType == ArkUI_NodeEventType::NODE_EVENT_ON_AREA_CHANGE) {
-        if (m_NodeDelegate) {
+        if (m_NodeDelegate && _isGeneratedPixelMap) {
             OH_PixelmapNative *pixelMap = GetNodePixelMap();
             if (!pixelMap) {
                 LOG(ERROR) << "[svgForeignNode] get node snapshot pixelMap is null";
                 return;
             }
+            _isGeneratedPixelMap = false;
             m_NodeDelegate->onDrawForeignImage(pixelMap, _width, _height, _positionX, _positionY);
         }
     }

--- a/tester/harmony/svg/src/main/cpp/SvgForeignObjectNode.h
+++ b/tester/harmony/svg/src/main/cpp/SvgForeignObjectNode.h
@@ -24,6 +24,9 @@ public:
     void SetSnapHeight(float height);
     OH_PixelmapNative *GetNodePixelMap();
     void SetForeignNodeDelegate(SvgForeignObjectNodeDelegate *delegate) { m_NodeDelegate = delegate; };
+    void SetGeneratedPixelMap(bool isNeed) {
+       _isGeneratedPixelMap = isNeed;
+    }
 
 private:
     StackNode mStackNode;
@@ -32,6 +35,7 @@ private:
     float _height{0};
     float _positionX{0};
     float _positionY{0};
+    bool _isGeneratedPixelMap{false}; //防止快照生成多次，导致性能影响
 };
 
 } // namespace svg

--- a/tester/harmony/svg/src/main/cpp/componentInstances/RNSVGForeignObjectComponentInstance.cpp
+++ b/tester/harmony/svg/src/main/cpp/componentInstances/RNSVGForeignObjectComponentInstance.cpp
@@ -29,6 +29,7 @@ void RNSVGForeignObjectComponentInstance::onFinalizeUpdates() {
                                           pointScaleFactor * std::stof(m_props->y));
         mForeignStackNode.SetSnapWidth(pointScaleFactor * std::stof(m_props->width));
         mForeignStackNode.SetSnapHeight(pointScaleFactor * std::stof(m_props->height));
+        mForeignStackNode.SetGeneratedPixelMap(true);		
     }
 }
 


### PR DESCRIPTION

# Summary

- Closed: #349 
- fix:修复foreignobject多次生成快照，导致的性能卡顿问题

## Checklist

<!-- 检查项, 请自行排查并打钩, 通过: [X] -->

- [X] 已经在真机设备或模拟器上测试通过
- [ ] 已经与 Android 或 iOS 平台做过效果/功能对比
- [ ] 已经添加了对应 API 的测试用例
- [ ] 已经更新了文档
- [ ] 更新了 JS/TS 代码
