### PR TITLE
fix: 修改使用watermark后list列表滑动阻塞的问题

### DIFF
--- a/tester/harmony/svg/src/main/cpp/componentInstances/RNSVGSvgViewComponentInstance.h
+++ b/tester/harmony/svg/src/main/cpp/componentInstances/RNSVGSvgViewComponentInstance.h
@@ -46,6 +46,10 @@ public:
 
     bool canChildrenHandleTouch() const override;
 
+    void onCreate() {
+        this->getLocalRootArkUINode().setArkUINodeDelegate(this);
+    }
+
 private:
     SvgArkUINode m_svgArkUINode;
     std::shared_ptr<SvgSvg> m_svgSvg = std::make_shared<SvgSvg>();


### PR DESCRIPTION
fix: 修改使用watermark后list列表滑动阻塞的问题
添加setArkUINodeDelegate的注册