### PR TITLE
feat:支持foreignObject支持opacity、matrix、mask、clipPath、clipRule等属性

### DIFF
--- a/tester/harmony/svg/src/main/cpp/SvgArkUINode.h
+++ b/tester/harmony/svg/src/main/cpp/SvgArkUINode.h
@@ -8,6 +8,7 @@
 
 #include "RNOH/arkui/ArkUINode.h"
 #include "SvgForeignObjectNodeDelegate.h"
+#include "SvgForeignProps.h"
 #include "SvgHost.h"
 #include "SvgNode.h"
 #include "arkui/native_node.h"
@@ -40,8 +41,7 @@ public:
     void SetGroupNode(const std::weak_ptr<SvgNode> &node) { _groupNode = node; }
     void ResetNodeHandle() {}
     void AddChild(ArkUINode &node);
-    void SetForeignObject(OH_PixelmapNative *pixelMap, float w, float h, float x, float y) {
-        ForeignProps foreignProps = {std::move(pixelMap), w, h, x, y};
+    void SetForeignObject(ForeignProps foreignProps) {
         if (auto groupNode = _groupNode.lock()) {
             groupNode->SetForeignObject(std::move(foreignProps));
         }

--- a/tester/harmony/svg/src/main/cpp/SvgForeignObjectNode.cpp
+++ b/tester/harmony/svg/src/main/cpp/SvgForeignObjectNode.cpp
@@ -44,7 +44,8 @@ void SvgForeignObjectNode::onNodeEvent(ArkUI_NodeEventType eventType, EventArgs 
                 return;
             }
             _isGeneratedPixelMap = false;
-            m_NodeDelegate->onDrawForeignImage(pixelMap, _width, _height, _positionX, _positionY);
+            ForeignProps foreignProps = {pixelMap, _width, _height, _positionX, _positionY, _path, _clipRule, _mask};
+            m_NodeDelegate->onDrawForeignImage(foreignProps);
         }
     }
 }

--- a/tester/harmony/svg/src/main/cpp/SvgForeignObjectNode.h
+++ b/tester/harmony/svg/src/main/cpp/SvgForeignObjectNode.h
@@ -27,7 +27,15 @@ public:
     void SetGeneratedPixelMap(bool isNeed) {
        _isGeneratedPixelMap = isNeed;
     }
-
+    
+    void SetClipPath(std::string path,int clipRule) {
+        _path = path;
+        _clipRule = clipRule;
+    }
+     void SetMask(std::string mask) {
+        _mask = mask;
+    }
+    
 private:
     StackNode mStackNode;
     SvgForeignObjectNodeDelegate *m_NodeDelegate;
@@ -35,6 +43,9 @@ private:
     float _height{0};
     float _positionX{0};
     float _positionY{0};
+    std::string _path{""};
+    std::string _mask{""};
+    int _clipRule{0};
     bool _isGeneratedPixelMap{false}; //防止快照生成多次，导致性能影响
 };
 

--- a/tester/harmony/svg/src/main/cpp/SvgForeignObjectNodeDelegate.h
+++ b/tester/harmony/svg/src/main/cpp/SvgForeignObjectNodeDelegate.h
@@ -6,10 +6,10 @@
 
 #ifndef HARMONY_SVGFOREIGNOBJECTNODEDELEGATE_H
 #define HARMONY_SVGFOREIGNOBJECTNODEDELEGATE_H
-#include <multimedia/image_framework/image/pixelmap_native.h>
+#include "SvgForeignProps.h"
 class SvgForeignObjectNodeDelegate {
 public:
     virtual ~SvgForeignObjectNodeDelegate() = default;
-    virtual void onDrawForeignImage(OH_PixelmapNative *foreignPixelMap,float width,float height,float x,float y){};
+    virtual void onDrawForeignImage(ForeignProps props){};
 };
 #endif //HARMONY_SVGFOREIGNOBJECTNODEDELEGATE_H

--- a/tester/harmony/svg/src/main/cpp/SvgForeignProps.h
+++ b/tester/harmony/svg/src/main/cpp/SvgForeignProps.h
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2025 Huawei Device Co., Ltd. All rights reserved
+ * Use of this source code is governed by a MIT license that can be
+ * found in the LICENSE file.
+ *
+ * This file incorporates from the OpenHarmony project, licensed under
+ * the Apache License, Version 2.0. Specifically:
+ * - [OpenHarmony/arkui_ace_engine] (https://gitee.com/openharmony/arkui_ace_engine)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at:
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+#ifndef HARMONY_FOREIGNPROPS_H
+#define HARMONY_FOREIGNPROPS_H
+#include <multimedia/image_framework/image/pixelmap_native.h>
+#include <string>
+struct ForeignProps {
+    OH_PixelmapNative *foreignPixelMap{nullptr};
+    float width;
+    float height;
+    float x;
+    float y;
+    std::string path;
+    int clipRule;
+    std::string mask;
+};
+#endif //HARMONY_FOREIGNPROPS_H

--- a/tester/harmony/svg/src/main/cpp/SvgNode.cpp
+++ b/tester/harmony/svg/src/main/cpp/SvgNode.cpp
@@ -269,11 +269,49 @@ double SvgNode::getCanvasDiagonal() {
     return canvasDiagonal_;
 }
 
+void SvgNode::DrawForeignClip(OH_Drawing_Canvas *canvas,const std::string &id,int clipRule) {
+    if (!context_) {
+        DLOG(INFO) << "[svgForeignNode] NO CONTEXT";
+        return;
+    }
+    auto refSvgNode = context_->GetSvgNodeById(id);
+    if (!refSvgNode) {
+        DLOG(WARNING) << "[svgForeignNode] clipPath: SvgNode is null!";
+        return;
+    };
+    auto clipPath = refSvgNode->AsPath();
+    drawing::Path::FillType fillType = clipRule == 0
+                                           ? OH_Drawing_PathFillType::PATH_FILL_TYPE_EVEN_ODD
+                                           : OH_Drawing_PathFillType::PATH_FILL_TYPE_WINDING;
+    clipPath.SetFillType(fillType);
+    OH_Drawing_CanvasClipPath(canvas, clipPath.get(), OH_Drawing_CanvasClipOp::INTERSECT, true);
+}
+
+void SvgNode::DrawForeignMask(OH_Drawing_Canvas *canvas, const std::string &id) {
+    if (!context_) {
+        DLOG(INFO) << "[svgForeignNode] NO CONTEXT";
+        return;
+    }
+    auto refMask = context_->GetSvgNodeById(id);
+    if (!refMask) {
+        return;
+    };
+    refMask->Draw(canvas);
+}
+
 void SvgNode::DrawForeignPixelMap(OH_Drawing_Canvas *canvas, ForeignProps _foreignProps) {
     if (!_foreignProps.foreignPixelMap) {
         DLOG(INFO) << "[svgForeignNode] foreignPixelMap is null";
         return;
     }
+    if (!_foreignProps.path.empty()) {
+        DrawForeignClip(canvas,_foreignProps.path, _foreignProps.clipRule);
+    }
+    
+    if (!_foreignProps.mask.empty()) {
+        DrawForeignMask(canvas,_foreignProps.mask);
+    }
+    
     DLOG(INFO) << "[svgForeignNode] DrawForeignPixelMap  start , width:" << _foreignProps.width;
     OH_Pixelmap_ImageInfo *imageInfo;
     OH_PixelmapImageInfo_Create(&imageInfo);

--- a/tester/harmony/svg/src/main/cpp/SvgNode.h
+++ b/tester/harmony/svg/src/main/cpp/SvgNode.h
@@ -24,6 +24,7 @@
 
 #include "SvgBaseAttribute.h"
 #include "SvgContext.h"
+#include "SvgForeignProps.h"
 #include "drawing/Path.h"
 #include "properties/Decoration.h"
 #include "properties/Dimension.h"
@@ -40,15 +41,6 @@
 
 namespace rnoh {
 namespace svg {
-
-struct ForeignProps {
-    OH_PixelmapNative *foreignPixelMap{nullptr};
-    float width;
-    float height;
-    float x;
-    float y;
-};
-
 
 constexpr int INHERIT_TYPE = 2;
 
@@ -206,6 +198,9 @@ protected:
 
     std::shared_ptr<PatternAttr> GetPatternAttr(const std::string &href);
     void DrawForeignPixelMap(OH_Drawing_Canvas *canvas,ForeignProps _foreignProps);
+    void DrawForeignMask(OH_Drawing_Canvas *canvas, const std::string &id);
+    void DrawForeignClip(OH_Drawing_Canvas *canvas, const std::string &id, int clipRule);
+    
     void InitNoneFlag() {
         hrefFill_ = false;
         hrefRender_ = false;

--- a/tester/harmony/svg/src/main/cpp/componentInstances/RNSVGForeignObjectComponentInstance.cpp
+++ b/tester/harmony/svg/src/main/cpp/componentInstances/RNSVGForeignObjectComponentInstance.cpp
@@ -29,7 +29,52 @@ void RNSVGForeignObjectComponentInstance::onFinalizeUpdates() {
                                           pointScaleFactor * std::stof(m_props->y));
         mForeignStackNode.SetSnapWidth(pointScaleFactor * std::stof(m_props->width));
         mForeignStackNode.SetSnapHeight(pointScaleFactor * std::stof(m_props->height));
-        mForeignStackNode.SetGeneratedPixelMap(true);		
+        mForeignStackNode.SetClipPath(m_props->clipPath, m_props->clipRule);
+        mForeignStackNode.SetMask(m_props->mask);
+        
+        auto childs = getChildren();
+        if (childs.size() > 0) {
+            for (ComponentInstance::Shared c : childs) {
+                if ((m_props->opacity > 0 && m_props->opacity != 1)) {
+                    setOpacity(c->getLocalRootArkUINode(), m_props->opacity);
+                }
+                transform(c->getLocalRootArkUINode());
+            }
+        }
+        mForeignStackNode.SetGeneratedPixelMap(true);
+    }
+}
+
+void RNSVGForeignObjectComponentInstance::transform(ArkUINode &node) {
+    // matrix 6 -> 16 ,2d->3d
+    if (m_props->matrix.size() != 6) {
+        return;
+    }
+    std::array<ArkUI_NumberValue, 16> transformValue;
+    for (int i = 0; i < 16; i++) {
+        if (i == 0 || i == 1) {
+            transformValue[i] = {.f32 = static_cast<float>(m_props->matrix[i])};
+        } else if (i == 4) {
+            transformValue[i] = {.f32 = static_cast<float>(m_props->matrix[2])};
+        } else if (i == 5) {
+            transformValue[i] = {.f32 = static_cast<float>(m_props->matrix[3])};
+        } else if (i == 10 || i == 15) {
+            transformValue[i] = {.f32 = static_cast<float>(1)};
+        } else if (i == 12) {
+            transformValue[i] = {.f32 = static_cast<float>(m_props->matrix[4])};
+        } else if (i == 13) {
+            transformValue[i] = {.f32 = static_cast<float>(m_props->matrix[5])};
+        } else {
+            transformValue[i] = {.f32 = static_cast<float>(0)};
+        }
+    }
+    ArkUI_AttributeItem transformItem = {transformValue.data(), transformValue.size()};
+    NativeNodeApi::getInstance()->setAttribute(node.getArkUINodeHandle(), NODE_TRANSFORM, &transformItem);
+}
+
+void RNSVGForeignObjectComponentInstance::setOpacity(ArkUINode &node, float op) {
+    if (op != 1) {
+        node.setOpacity(m_props->opacity);
     }
 }
 

--- a/tester/harmony/svg/src/main/cpp/componentInstances/RNSVGForeignObjectComponentInstance.h
+++ b/tester/harmony/svg/src/main/cpp/componentInstances/RNSVGForeignObjectComponentInstance.h
@@ -10,6 +10,7 @@
 #include "SvgForeignObjectNode.h"
 #include <react/renderer/components/react_native_svg/ShadowNodes.h>
 #include "RNOH/arkui/ColumnNode.h"
+#include "RNOH/arkui/NativeNodeApi.h"
 namespace rnoh {
 namespace svg {
 class RNSVGForeignObjectComponentInstance : public CppComponentInstance<facebook::react::RNSVGForeignObjectShadowNode> {
@@ -23,7 +24,10 @@ public:
     void onChildRemoved(ComponentInstance::Shared const &childComponentInstance) override;
 
     SvgForeignObjectNode &getLocalRootArkUINode() override;
-
+    
+    void setOpacity(ArkUINode &node, float op);
+    
+    void transform(ArkUINode &node);
 private:
     SvgForeignObjectNode mForeignStackNode;
     ColumnNode node;

--- a/tester/harmony/svg/src/main/cpp/componentInstances/RNSVGSvgViewComponentInstance.cpp
+++ b/tester/harmony/svg/src/main/cpp/componentInstances/RNSVGSvgViewComponentInstance.cpp
@@ -46,12 +46,11 @@ void RNSVGSvgViewComponentInstance::onFinalizeUpdates() {
     getLocalRootArkUINode().markDirty();
 }
 
-void RNSVGSvgViewComponentInstance::onDrawForeignImage(OH_PixelmapNative *foreignPixelMap, float width, float height,
-                                                       float x, float y) {
-    if (foreignPixelMap) {
-        DLOG(INFO) << "[svgForeignNode] RNSVGSvgViewComponentInstance OH_PixelmapNative is not null, position:{ x:" << x
-                   << ",y:" << y << "},width:" << width << ";height:" << height;
-        m_svgArkUINode.SetForeignObject(foreignPixelMap, width, height, x, y);
+void RNSVGSvgViewComponentInstance::onDrawForeignImage(ForeignProps foreignProps) {
+    if (foreignProps.foreignPixelMap) {
+        DLOG(INFO) << "[svgForeignNode] RNSVGSvgViewComponentInstance OH_PixelmapNative is not null, position:{ x:" << foreignProps.x
+                   << ",y:" << foreignProps.y << "},width:" << foreignProps.width << ";height:" << foreignProps.height;
+        m_svgArkUINode.SetForeignObject(foreignProps);
         m_svgArkUINode.markDirty();
     } else {
         DLOG(INFO) << "RNSVGSvgViewComponentInstance OH_PixelmapNative is null";

--- a/tester/harmony/svg/src/main/cpp/componentInstances/RNSVGSvgViewComponentInstance.h
+++ b/tester/harmony/svg/src/main/cpp/componentInstances/RNSVGSvgViewComponentInstance.h
@@ -31,7 +31,7 @@ public:
     ~RNSVGSvgViewComponentInstance();
 
     void onFinalizeUpdates() override;
-    void onDrawForeignImage(OH_PixelmapNative *foreignPixelMap,float width,float height,float x,float y) override;
+    void onDrawForeignImage(ForeignProps foreignProps) override;
     // get SvgNode from childComponentInstance and set it to root_
     void onChildInserted(ComponentInstance::Shared const &childComponentInstance, std::size_t index) override;
 


### PR DESCRIPTION
# Summary

- feat:支持foreignObject支持opacity、matrix、mask、clipPath、clipRule等属性
- Close: #364 


## Checklist

- [X] 已经在真机设备或模拟器上测试通过
- [X] 已经与 Android 或 iOS 平台做过效果/功能对比
- [ ] 已经添加了对应 API 的测试用例（如需要）
- [ ] 已经更新了文档（如需要）
- [ ] 更新了 JS/TS 代码 (如有)
