### PR TITLE
fix:修复在SvgGradient::SetAttrGradient()方法中，每次props更新时未清空旧的渐变颜色数组，导致颜色停止点数据累积，最终传递给Native Drawing API的数据异常

### DIFF
--- a/tester/harmony/svg/src/main/cpp/SvgGradient.cpp
+++ b/tester/harmony/svg/src/main/cpp/SvgGradient.cpp
@@ -70,6 +70,7 @@ void SvgGradient::SetAttrRy(const std::string& ry) {
 
 void SvgGradient::SetAttrGradient(std::vector<Float> gradient) {
     auto stopCount = gradient.size() / 2;
+    gradientAttr_.gradient.ClearColors();
     for (auto i = 0; i < stopCount; i++) {
         auto stopIndex = i * 2;
         GradientColor gradientColor;


### PR DESCRIPTION
fix:修复在SvgGradient::SetAttrGradient()方法中，每次props更新时未清空旧的渐变颜色数组，导致颜色停止点数据累积，最终传递给Native Drawing API的数据异常
<!-- 感谢您提交PR！请按照模板填写，以便审阅者可以轻松理解和评估代码变更的影响。-->

# Summary

请解释此次更改的 **动机**，以下是一些帮助您的要点：
- 这个 PR 解决了哪些 issues？请标记这些 issues，以便合并 PR 后这些 issues 将会被自动关闭。
- Close:#369
- 这个功能是什么？（如果适用）
-在SvgGradient::SetAttrGradient()方法中，每次props更新时未清空旧的渐变颜色数组，导致颜色停止点数据累积，最终传递给Native Drawing API的数据异常，修复这个问题
- 您是如何实现解决方案的？
- 添加gradientAttr_.gradient.ClearColors();
- 这个更改影响了库的哪些部分？

## Test Plan
展示代码的稳定性。例如：用来复现场景的命令输入和结果输出、测试用例的路径地址，或者附上截图和视频。

## Checklist

<!-- 检查项, 请自行排查并打钩, 通过: [X] -->

- [x] 已经在真机设备或模拟器上测试通过
- [x] 已经与 Android 或 iOS 平台做过效果/功能对比
- [ ] 已经添加了对应 API 的测试用例（如需要）
- [ ] 已经更新了文档（如需要）
- [x] 更新了 JS/TS 代码 (如有)
