### PR TITLE
fix：修复foreignobject的属性中设置的string值，导致显示的位置或者宽高有差异

### DIFF
--- a/tester/harmony/svg/src/main/cpp/SvgForeignObjectNode.cpp
+++ b/tester/harmony/svg/src/main/cpp/SvgForeignObjectNode.cpp
@@ -26,11 +26,11 @@ SvgForeignObjectNode::~SvgForeignObjectNode() {
 }
 void SvgForeignObjectNode::insertChild(ArkUINode &child, std::size_t index) { mStackNode.insertChild(child, index); }
 
-void SvgForeignObjectNode::SetSnapHeight(float height) { _height = height; }
+void SvgForeignObjectNode::SetSnapHeight(Dimension height) { _height = height; }
 
-void SvgForeignObjectNode::SetSnapWidth(float width) { _width = width; }
+void SvgForeignObjectNode::SetSnapWidth(Dimension width) { _width = width; }
 
-void SvgForeignObjectNode::SetSnapPosition(float x, float y) {
+void SvgForeignObjectNode::SetSnapPosition(Dimension x, Dimension y) {
     _positionX = x;
     _positionY = y;
 }
@@ -44,7 +44,8 @@ void SvgForeignObjectNode::onNodeEvent(ArkUI_NodeEventType eventType, EventArgs 
                 return;
             }
             _isGeneratedPixelMap = false;
-            ForeignProps foreignProps = {pixelMap, _width, _height, _positionX, _positionY, _path, _clipRule, _mask};
+            ForeignProps foreignProps = {pixelMap, _width, _height, _positionX, 
+                _positionY, _path, _clipRule, _mask, pointScaleFactor_, transform_};
             m_NodeDelegate->onDrawForeignImage(foreignProps);
         }
     }

--- a/tester/harmony/svg/src/main/cpp/SvgForeignObjectNode.h
+++ b/tester/harmony/svg/src/main/cpp/SvgForeignObjectNode.h
@@ -9,6 +9,7 @@
 #include "RNOH/arkui/ArkUINode.h"
 #include "RNOH/arkui/StackNode.h"
 #include "SvgForeignObjectNodeDelegate.h"
+#include "properties/Dimension.h"
 
 namespace rnoh {
 namespace svg {
@@ -19,9 +20,18 @@ public:
     void onNodeEvent(ArkUI_NodeEventType eventType, EventArgs &eventArgs) override;
     StackNode &getSnapNode() { return mStackNode; }
     void insertChild(ArkUINode &child, std::size_t index);
-    void SetSnapPosition(float x, float y);
-    void SetSnapWidth(float width);
-    void SetSnapHeight(float height);
+    void SetSnapPosition(Dimension x, Dimension y);
+    void SetSnapWidth(Dimension width);
+    void SetSnapHeight(Dimension height);
+    void SetPointScaleFactor(float pointScaleFactor) {
+        pointScaleFactor_ = pointScaleFactor;
+    }
+    void SetTransform(std::vector<double> transform) {
+        transform_ = transform;
+    }
+    void setNodeSize(float w, float h){
+        mStackNode.setSize({w, h});
+    }
     OH_PixelmapNative *GetNodePixelMap();
     void SetForeignNodeDelegate(SvgForeignObjectNodeDelegate *delegate) { m_NodeDelegate = delegate; };
     void SetGeneratedPixelMap(bool isNeed) {
@@ -39,13 +49,15 @@ public:
 private:
     StackNode mStackNode;
     SvgForeignObjectNodeDelegate *m_NodeDelegate;
-    float _width{0};
-    float _height{0};
-    float _positionX{0};
-    float _positionY{0};
+    Dimension _width{0};
+    Dimension _height{0};
+    Dimension _positionX{0};
+    Dimension _positionY{0};
     std::string _path{""};
     std::string _mask{""};
+    std::vector<double> transform_;
     int _clipRule{0};
+    float pointScaleFactor_{0};
     bool _isGeneratedPixelMap{false}; //防止快照生成多次，导致性能影响
 };
 

--- a/tester/harmony/svg/src/main/cpp/SvgForeignProps.h
+++ b/tester/harmony/svg/src/main/cpp/SvgForeignProps.h
@@ -21,16 +21,19 @@
 
 #ifndef HARMONY_FOREIGNPROPS_H
 #define HARMONY_FOREIGNPROPS_H
+#include "properties/Dimension.h"
 #include <multimedia/image_framework/image/pixelmap_native.h>
 #include <string>
 struct ForeignProps {
     OH_PixelmapNative *foreignPixelMap{nullptr};
-    float width;
-    float height;
-    float x;
-    float y;
+    rnoh::svg::Dimension width;
+    rnoh::svg::Dimension height;
+    rnoh::svg::Dimension x;
+    rnoh::svg::Dimension y;
     std::string path;
     int clipRule;
     std::string mask;
+    float pointScaleFactor;
+    std::vector<double> transform;
 };
 #endif //HARMONY_FOREIGNPROPS_H

--- a/tester/harmony/svg/src/main/cpp/SvgNode.cpp
+++ b/tester/harmony/svg/src/main/cpp/SvgNode.cpp
@@ -127,10 +127,8 @@ void SvgNode::OnMask(OH_Drawing_Canvas *canvas) {
     refMask->Draw(canvas);
 }
 
-void SvgNode::OnTransform(OH_Drawing_Canvas *canvas) {
+void SvgNode::OnTransform(OH_Drawing_Canvas *canvas, std::vector<double> transform) {
     // input transfrom: (float scaleX, float skewY, float skewX, float scaleY, float transX, float transY)
-    const auto &transform = attributes_.transform;
-    /*
     /* (OH_Drawing_Matrix* , float scaleX, float skewX, float transX, float skewY, float scaleY, float transY, float
     persp0, float persp1, float persp2 )
     */
@@ -179,7 +177,7 @@ void SvgNode::Draw(OH_Drawing_Canvas *canvas) {
     const auto count = OH_Drawing_CanvasGetSaveCount(canvas);
     OH_Drawing_CanvasSave(canvas);
     if (!attributes_.transform.empty()) {
-        OnTransform(canvas);
+        OnTransform(canvas, attributes_.transform);
     }
     if (!hrefClipPath_.empty()) {
         OnClipPath(canvas);
@@ -304,6 +302,9 @@ void SvgNode::DrawForeignPixelMap(OH_Drawing_Canvas *canvas, ForeignProps _forei
         DLOG(INFO) << "[svgForeignNode] foreignPixelMap is null";
         return;
     }
+    if (!_foreignProps.transform.empty()) {
+        OnTransform(canvas, _foreignProps.transform);
+    }
     if (!_foreignProps.path.empty()) {
         DrawForeignClip(canvas,_foreignProps.path, _foreignProps.clipRule);
     }
@@ -311,8 +312,10 @@ void SvgNode::DrawForeignPixelMap(OH_Drawing_Canvas *canvas, ForeignProps _forei
     if (!_foreignProps.mask.empty()) {
         DrawForeignMask(canvas,_foreignProps.mask);
     }
-    
-    DLOG(INFO) << "[svgForeignNode] DrawForeignPixelMap  start , width:" << _foreignProps.width;
+    double postionX = _foreignProps.x.ParsePropsToPx(OH_Drawing_CanvasGetWidth(canvas), _foreignProps.pointScaleFactor);
+    double postionY = _foreignProps.y.ParsePropsToPx(OH_Drawing_CanvasGetHeight(canvas), _foreignProps.pointScaleFactor);
+    double foreignW = _foreignProps.width.ParsePropsToPx(OH_Drawing_CanvasGetWidth(canvas), _foreignProps.pointScaleFactor);
+    double foreignH = _foreignProps.height.ParsePropsToPx(OH_Drawing_CanvasGetHeight(canvas), _foreignProps.pointScaleFactor);
     OH_Pixelmap_ImageInfo *imageInfo;
     OH_PixelmapImageInfo_Create(&imageInfo);
 
@@ -327,7 +330,9 @@ void SvgNode::DrawForeignPixelMap(OH_Drawing_Canvas *canvas, ForeignProps _forei
         OH_PixelmapNative_Release(_foreignProps.foreignPixelMap);
         return;
     }
-
+    float  originalRelWidth  = originalWidth > foreignW ? foreignW : originalWidth;
+    float  originalRelHeight  = originalHeight > foreignH ? foreignH : originalHeight;
+    DLOG(INFO) << "[svgForeignNode] DrawForeignPixelMap start , foreignH:" << foreignH << ";originalHeight:" << originalHeight <<";originalRelHeight:" << originalRelHeight;
     OH_Drawing_PixelMap *ohPixelMap = OH_Drawing_PixelMapGetFromOhPixelMapNative(_foreignProps.foreignPixelMap);
     if (!ohPixelMap) {
         DLOG(WARNING) << "[svgForeignNode] Failed to get OH_Drawing_PixelMap";
@@ -337,15 +342,12 @@ void SvgNode::DrawForeignPixelMap(OH_Drawing_Canvas *canvas, ForeignProps _forei
 
     OH_Drawing_CanvasSave(canvas);
 
-    OH_Drawing_CanvasTranslate(canvas, _foreignProps.x, _foreignProps.y);
-
-
-    float scaleX = static_cast<float>(_foreignProps.width) / originalWidth;
-    float scaleY = static_cast<float>(_foreignProps.height) / originalHeight;
+    OH_Drawing_CanvasTranslate(canvas, postionX, postionY);
+    
     OH_Drawing_CanvasScale(canvas, 1, 1);
 
-    OH_Drawing_Rect *srcRect = OH_Drawing_RectCreate(0, 0, originalWidth, originalHeight);
-    OH_Drawing_Rect *dstRect = OH_Drawing_RectCreate(0, 0, originalWidth, originalHeight);
+    OH_Drawing_Rect *srcRect = OH_Drawing_RectCreate(0, 0, originalRelWidth, originalRelHeight);
+    OH_Drawing_Rect *dstRect = OH_Drawing_RectCreate(0, 0, originalRelWidth, originalRelHeight);
     OH_Drawing_SamplingOptions *sampling = OH_Drawing_SamplingOptionsCreate(FILTER_MODE_LINEAR, MIPMAP_MODE_LINEAR);
     OH_Drawing_CanvasDrawPixelMapRect(canvas, ohPixelMap, srcRect, dstRect, sampling);
 

--- a/tester/harmony/svg/src/main/cpp/SvgNode.h
+++ b/tester/harmony/svg/src/main/cpp/SvgNode.h
@@ -187,7 +187,7 @@ protected:
 
     void OnClipPath(OH_Drawing_Canvas *canvas);
     void OnMask(OH_Drawing_Canvas *canvas);
-    void OnTransform(OH_Drawing_Canvas *canvas);
+    void OnTransform(OH_Drawing_Canvas *canvas, std::vector<double> transform);
 
     const Rect &GetRootViewBox() const;
 

--- a/tester/harmony/svg/src/main/cpp/componentInstances/RNSVGForeignObjectComponentInstance.cpp
+++ b/tester/harmony/svg/src/main/cpp/componentInstances/RNSVGForeignObjectComponentInstance.cpp
@@ -24,52 +24,31 @@ RNSVGForeignObjectComponentInstance::~RNSVGForeignObjectComponentInstance() {
 void RNSVGForeignObjectComponentInstance::onFinalizeUpdates() {
     ComponentInstance::onFinalizeUpdates();
     if (m_props) {
-        float pointScaleFactor = getLayoutMetrics().pointScaleFactor;
-        mForeignStackNode.SetSnapPosition(pointScaleFactor * std::stof(m_props->x),
-                                          pointScaleFactor * std::stof(m_props->y));
-        mForeignStackNode.SetSnapWidth(pointScaleFactor * std::stof(m_props->width));
-        mForeignStackNode.SetSnapHeight(pointScaleFactor * std::stof(m_props->height));
+        mForeignStackNode.SetPointScaleFactor(getLayoutMetrics().pointScaleFactor);
+        mForeignStackNode.SetSnapPosition(propsConversionValue(m_props->x), propsConversionValue(m_props->y));
+        mForeignStackNode.SetSnapWidth(propsConversionValue(m_props->width));
+        mForeignStackNode.SetSnapHeight(propsConversionValue(m_props->height));
+
         mForeignStackNode.SetClipPath(m_props->clipPath, m_props->clipRule);
         mForeignStackNode.SetMask(m_props->mask);
-        
+        mForeignStackNode.SetTransform(m_props->matrix);
         auto childs = getChildren();
         if (childs.size() > 0) {
             for (ComponentInstance::Shared c : childs) {
                 if ((m_props->opacity > 0 && m_props->opacity != 1)) {
                     setOpacity(c->getLocalRootArkUINode(), m_props->opacity);
                 }
-                transform(c->getLocalRootArkUINode());
             }
         }
         mForeignStackNode.SetGeneratedPixelMap(true);
     }
 }
 
-void RNSVGForeignObjectComponentInstance::transform(ArkUINode &node) {
-    // matrix 6 -> 16 ,2d->3d
-    if (m_props->matrix.size() != 6) {
-        return;
+Dimension RNSVGForeignObjectComponentInstance::propsConversionValue(const folly::dynamic &d) {
+    if (d.isNull()) {
+        return Dimension(0, DimensionUnit::INVALID);
     }
-    std::array<ArkUI_NumberValue, 16> transformValue;
-    for (int i = 0; i < 16; i++) {
-        if (i == 0 || i == 1) {
-            transformValue[i] = {.f32 = static_cast<float>(m_props->matrix[i])};
-        } else if (i == 4) {
-            transformValue[i] = {.f32 = static_cast<float>(m_props->matrix[2])};
-        } else if (i == 5) {
-            transformValue[i] = {.f32 = static_cast<float>(m_props->matrix[3])};
-        } else if (i == 10 || i == 15) {
-            transformValue[i] = {.f32 = static_cast<float>(1)};
-        } else if (i == 12) {
-            transformValue[i] = {.f32 = static_cast<float>(m_props->matrix[4])};
-        } else if (i == 13) {
-            transformValue[i] = {.f32 = static_cast<float>(m_props->matrix[5])};
-        } else {
-            transformValue[i] = {.f32 = static_cast<float>(0)};
-        }
-    }
-    ArkUI_AttributeItem transformItem = {transformValue.data(), transformValue.size()};
-    NativeNodeApi::getInstance()->setAttribute(node.getArkUINodeHandle(), NODE_TRANSFORM, &transformItem);
+    return StringUtils::StringToDimension(d.asString(), true);
 }
 
 void RNSVGForeignObjectComponentInstance::setOpacity(ArkUINode &node, float op) {
@@ -81,6 +60,9 @@ void RNSVGForeignObjectComponentInstance::setOpacity(ArkUINode &node, float op) 
 void RNSVGForeignObjectComponentInstance::onChildInserted(ComponentInstance::Shared const &childComponentInstance,
                                                           std::size_t index) {
     CppComponentInstance::onChildInserted(childComponentInstance, index);
+    float width = childComponentInstance->getLayoutMetrics().frame.size.width;
+    float height = childComponentInstance->getLayoutMetrics().frame.size.height;
+    mForeignStackNode.setNodeSize(width, height);
     node.insertChild(childComponentInstance->getLocalRootArkUINode(), index);
 }
 

--- a/tester/harmony/svg/src/main/cpp/componentInstances/RNSVGForeignObjectComponentInstance.h
+++ b/tester/harmony/svg/src/main/cpp/componentInstances/RNSVGForeignObjectComponentInstance.h
@@ -11,6 +11,8 @@
 #include <react/renderer/components/react_native_svg/ShadowNodes.h>
 #include "RNOH/arkui/ColumnNode.h"
 #include "RNOH/arkui/NativeNodeApi.h"
+#include "properties/Dimension.h"
+#include "utils/StringUtils.h"
 namespace rnoh {
 namespace svg {
 class RNSVGForeignObjectComponentInstance : public CppComponentInstance<facebook::react::RNSVGForeignObjectShadowNode> {
@@ -27,7 +29,7 @@ public:
     
     void setOpacity(ArkUINode &node, float op);
     
-    void transform(ArkUINode &node);
+    Dimension propsConversionValue(const folly::dynamic& d);
 private:
     SvgForeignObjectNode mForeignStackNode;
     ColumnNode node;

--- a/tester/harmony/svg/src/main/cpp/componentInstances/RNSVGSvgViewComponentInstance.cpp
+++ b/tester/harmony/svg/src/main/cpp/componentInstances/RNSVGSvgViewComponentInstance.cpp
@@ -48,8 +48,8 @@ void RNSVGSvgViewComponentInstance::onFinalizeUpdates() {
 
 void RNSVGSvgViewComponentInstance::onDrawForeignImage(ForeignProps foreignProps) {
     if (foreignProps.foreignPixelMap) {
-        DLOG(INFO) << "[svgForeignNode] RNSVGSvgViewComponentInstance OH_PixelmapNative is not null, position:{ x:" << foreignProps.x
-                   << ",y:" << foreignProps.y << "},width:" << foreignProps.width << ";height:" << foreignProps.height;
+        DLOG(INFO) << "[svgForeignNode] RNSVGSvgViewComponentInstance OH_PixelmapNative is not null, position:{ x:" << foreignProps.x.Value()
+                   << ",y:" << foreignProps.y.Value() << "},width:" << foreignProps.width.Value() << ";height:" << foreignProps.height.Value();
         m_svgArkUINode.SetForeignObject(foreignProps);
         m_svgArkUINode.markDirty();
     } else {

--- a/tester/harmony/svg/src/main/cpp/properties/Dimension.h
+++ b/tester/harmony/svg/src/main/cpp/properties/Dimension.h
@@ -141,6 +141,20 @@ public:
         return 0.0;
     };
 
+    double ParsePropsToPx(double relative, float pointScaleFactor){
+        if (unit_ == DimensionUnit::NONE) {
+            return value_*pointScaleFactor;
+        }
+        if (unit_ == DimensionUnit::PERCENT) {
+            return value_*relative - pointScaleFactor;
+        }
+        if (unit_ == DimensionUnit::VP) {
+            return value_*pointScaleFactor;
+        } else {
+            return value_;
+        }  
+    }
+    
     double GetNativeValue(DimensionUnit unit, double scale) const {
         if (unit_ == unit) {
             return value_;


### PR DESCRIPTION
# Summary

请解释此次更改的 **动机**，以下是一些帮助您的要点：

- fix：修复foreignobject的属性中设置的string值，导致显示的位置或者宽高有差异
- Closed: #373 

## Checklist

<!-- 检查项, 请自行排查并打钩, 通过: [X] -->

- [X] 已经在真机设备或模拟器上测试通过
- [X] 已经与 Android 或 iOS 平台做过效果/功能对比
- [ ] 已经添加了对应 API 的测试用例（如需要）
- [ ] 已经更新了文档（如需要）
- [ ] 更新了 JS/TS 代码 (如有)